### PR TITLE
Update fhir-ig-list.json

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -4110,31 +4110,6 @@
       ]
     },
     {
-      "name": "eHealth Platform Federal Core Profiles",
-      "category": "Public Health",
-      "npm-name": "be.ehealthplatform.fihr.be-core",
-      "description": "eHealth Platform Federal Core Profiles",
-      "authority": "eHealth Platform",
-      "country": "be",
-      "history": "https://www.ehealth.fgov.be/standards/fhir/history.html",
-      "language": [
-        "en"
-      ],
-      "canonical": "https://www.ehealth.fgov.be/standards/fhir",
-      "ci-build": "build.fhir.org/ig/hl7-be/be-core",
-      "editions": [
-        {
-          "name": "Official Releases",
-          "ig-version": "1.2.3",
-          "package": "be.ehealthplatform.fihr.be-core#1.2.3",
-          "fhir-version": [
-            "4.0.1"
-          ],
-          "url": "https://www.ehealth.fgov.be/standards/fhir/1.2.3"
-        }
-      ]
-    },
-    {
       "name": "CDC Opioid MME Calculator",
       "category": "Quality / CDS",
       "npm-name": "fhir.cdc.opioid-mme-r4",
@@ -4403,6 +4378,31 @@
             "4.0.1"
           ],
           "url": "https://profiles.ihe.net/RAD/IMR/1.0.0-comment"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Core profiles",
+      "category": "test",
+      "npm-name": "hl7.fhir.be.core",
+      "description": "Belgian Federal Core Profiles",
+      "authority": "eHealth Platform",
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/core",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/core",
+      "editions": [
+        {
+          "name": "Trial Use Test",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.be.core#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/core/2.0.0"
         }
       ]
     }

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -59,9 +59,18 @@
       "name": "IHE International",
       "url": "https://profiles.ihe.net/fhir/package-feed.xml",
       "errors": "secretary|ihe_net"
+    },
+    {
+      "name": "HL7 Belgium/eHealth Platform",
+      "url": "https://www.ehealth.fgov.be/standards/fhir/package-feed.xml",
+      "errors": "message-structure|ehealth_fgov_be"
     }
   ],
   "package-restrictions": [
+	{
+      "mask": "hl7.fhir.be.*",
+      "feeds": [ "https://www.ehealth.fgov.be/standards/fhir/package-feed.xml" ]
+    },
     {
       "mask": "hl7.fhir.au.*",
       "feeds": [ "http://hl7.org.au/fhir/package-feed.xml" ]


### PR DESCRIPTION
first release of version v2.0.0

The version will be live at https://www.ehealth.fgov.be/standards/fhir/core from 25/03/2022 17h00 CET

@grahamegrieve , @costateixeira
