### PR TITLE
update fhir-ig-list.json

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7140,7 +7140,7 @@
         "en"
       ],
       "canonical": "http://hl7.org/fhir/uv/vulcan-schedule",
-      "ci-build": "http://build.fhir.org/ig/HL7/vulcan-rwd",
+      "ci-build": "http://build.fhir.org/ig/HL7/vulcan-schedule",
       "editions": [
         {
           "name": "STU1 Ballot",


### PR DESCRIPTION
history page for clinical study schedule pointing to ci-build for real-world-data. also need to update package-list in uv/vulcan-schedule.