### PR TITLE
Update fhir-ig-list.json

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -561,7 +561,7 @@
       ],
       "history": "http://hl7.org/fhir/us/qicore/history.html",
       "canonical": "http://hl7.org/fhir/us/qicore",
-      "ci-build": "http://build.fhir.org/ig/cqframework/qi-core",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-qi-core",
       "analysis": {
         "content": true,
         "clinicalCore": true,


### PR DESCRIPTION
The QI-Core IG is autogenerating an incorrect ciURL of http://build.fhir.org/ig/cqframework/qi-core in the spec xml when it should be the following URL http://build.fhir.org/ig/HL7/fhir-qi-core. It was discussed in the following zulip thread (https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/ciUrl.20generation.20in.20IG.20specification.20xml) and Lloyd informed us that we should reach out to get this sorted out in order for STU5 publication to proceed. Please let me know if you need anything on my end.

Regards,
Abdullah
