### PR TITLE
Hl7korea

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7778,6 +7778,34 @@
           "url": "http://fhir.kl.dk/children/1.0.0"
         }
       ]
+    },
+    {
+      "name": "KR Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.kr.core",
+      "description": "Base Korean national implementation guide",
+      "authority": "HL7 Korea",
+      "product": [
+        "fhir"
+      ],
+      "country": "kr",
+      "language": [
+        "kr",
+        "en"
+      ],
+      "history": "http://www.hl7korea.or.kr/fhir/krcore/history.html",
+      "canonical": "http://www.hl7korea.or.kr/fhir/krcore",
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.kr.core#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://www.hl7korea.or.kr/fhir/krcore/STU1.0.1/"
+        }
+      ]
     }
   ]
 }

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -130,6 +130,11 @@
       "name": "Common FHIR profile vendor collaboration",
       "url": "https://commonprofiles.care/package-feed.xml",
       "errors": "info|commonprofiles.care"
+    },
+    {
+      "name": "HL7 Korea",
+      "url": "http://www.hl7korea.or.kr/fhir/package-feed.xml",
+      "errors": "jhsong|healthall_co_kr"
     }
   ],
   "package-restrictions": [
@@ -202,6 +207,10 @@
     {
       "mask": "silth.fhir.*",
       "feeds": [ "https://fhir-ig.sil-th.org/package-feed.xml", "https://terms.sil-th.org/package-feed.xml" ]
+    },
+    {
+      "mask": "hl7.fhir.kr.*",
+      "feeds": [ "http://www.hl7korea.or.kr/fhir/package-feed.xml" ]
     }
   ]
 }  


### PR DESCRIPTION
HL7 Korea finally published KR Core IG(Implementation Guide) in June 2023 after performing Balloting as well as Connectathon. HL7 Korea would like the KR Core IG to be registered into the IG Registry. So please review this request.