### PR TITLE
Add Finnish FHIR IG's

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7489,6 +7489,56 @@
           "url": "http://hl7.se/fhir/ig/base/1.0.0"
         }
       ]
+    },
+    {
+      "name": "Finnish Implementation Guide for SMART App Launch",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.fi.smart",
+      "description": "Guidelines for using the SMART App Launch mechanism in Finland, published and maintained by HL7 Finland.",
+      "authority": "HL7",
+      "country": "FI",
+      "history": "https://hl7.fi/fhir/finnish-smart/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.fi/fhir/finnish-smart",
+      "ci-build": "https://fhir.fi/finnish-smart/",
+      "editions": [
+        {
+          "name": "Release 1.0.0, STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fi.smart#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.fi/fhir/finnish-smart/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Finnish Base Profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.fi.smart",
+      "description": "A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland",
+      "authority": "HL7",
+      "country": "FI",
+      "history": "https://hl7.fi/fhir/finnish-base-profiles/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.fi/fhir/finnish-base-profiles+",
+      "ci-build": "https://fhir.fi/finnish-base-profiles/",
+      "editions": [
+        {
+          "name" : "Release 1.0.0, STU 1",
+          "ig-version" : "1.0.0",
+          "package": "hl7.fi.base#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url" : "https://hl7.fi/fhir/finnish-base-profiles/1.0.0"
+        }
+      ]
     }
   ]
 }

--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7530,13 +7530,38 @@
       "ci-build": "https://fhir.fi/finnish-base-profiles",
       "editions": [
         {
-          "name": "Release 1.0.0, STU 1",
-          "ig-version": "1.0.0",
-          "package": "hl7.fhir.fi.base#1.0.0",
+          "name": "STU 1 Qa-preview",
+          "ig-version": "1.0.0-rc20",
+          "package": "hl7.fhir.fi.base#1.0.0-rc20",
           "fhir-version": [
             "4.0.1"
           ],
-          "url": "https://hl7.fi/fhir/finnish-base-profiles/1.0.0"
+          "url": "https://hl7.fi/fhir/finnish-base-profiles/1.0-rc20"
+        }
+      ]
+    },
+    {
+      "name": "Finnish Scheduling",
+      "category": "Workflow",
+      "npm-name": "hl7.fhir.fi.scheduling",
+      "description": "Finnish HL7 FHIR implementation guide for scheduling, published and maintained by HL7 Finland",
+      "authority": "HL7",
+      "country": "FI",
+      "history": "https://hl7.fi/fhir/finnish-scheduling/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.fi/fhir/finnish-scheduling",
+      "ci-build": "https://fhir.fi/finnish-scheduling",
+      "editions": [
+        {
+          "name": "STU 1 Draft",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.fi.scheduling#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.fi/fhir/finnish-scheduling/0.1.0"
         }
       ]
     }

--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7492,8 +7492,8 @@
     },
     {
       "name": "Finnish Implementation Guide for SMART App Launch",
-      "category": "National Base",
       "npm-name": "hl7.fhir.fi.smart",
+      "category": "National Base",
       "description": "Guidelines for using the SMART App Launch mechanism in Finland, published and maintained by HL7 Finland.",
       "authority": "HL7",
       "country": "FI",
@@ -7502,12 +7502,12 @@
         "en"
       ],
       "canonical": "https://hl7.fi/fhir/finnish-smart",
-      "ci-build": "https://fhir.fi/finnish-smart/",
+      "ci-build": "https://fhir.fi/finnish-smart",
       "editions": [
         {
           "name": "Release 1.0.0, STU 1",
           "ig-version": "1.0.0",
-          "package": "hl7.fi.smart#1.0.0",
+          "package": "hl7.fhir.fi.smart#1.0.0",
           "fhir-version": [
             "4.0.1"
           ],
@@ -7518,7 +7518,7 @@
     {
       "name": "Finnish Base Profiles",
       "category": "National Base",
-      "npm-name": "hl7.fhir.fi.smart",
+      "npm-name": "hl7.fhir.fi.base",
       "description": "A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland",
       "authority": "HL7",
       "country": "FI",
@@ -7526,17 +7526,17 @@
       "language": [
         "en"
       ],
-      "canonical": "https://hl7.fi/fhir/finnish-base-profiles+",
-      "ci-build": "https://fhir.fi/finnish-base-profiles/",
+      "canonical": "https://hl7.fi/fhir/finnish-base-profiles",
+      "ci-build": "https://fhir.fi/finnish-base-profiles",
       "editions": [
         {
-          "name" : "Release 1.0.0, STU 1",
-          "ig-version" : "1.0.0",
-          "package": "hl7.fi.base#1.0.0",
+          "name": "Release 1.0.0, STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.fi.base#1.0.0",
           "fhir-version": [
             "4.0.1"
           ],
-          "url" : "https://hl7.fi/fhir/finnish-base-profiles/1.0.0"
+          "url": "https://hl7.fi/fhir/finnish-base-profiles/1.0.0"
         }
       ]
     }

--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7579,7 +7579,8 @@
         }
       ]
     },
-    {      "name": "KLFFBMessaging",
+    {
+      "name": "KLFFBMessaging",
       "category": "Messaging",
       "npm-name": "kl.dk.fhir.ffbmessaging",
       "description": "Danish municipalities implementation guide for FFB messaging. A standard for exchanging social information from citizen journals between municipalities. The aim is to support citizens continuously, e.g. when they move, or receives interventions outside their home municipality.",
@@ -7793,13 +7794,13 @@
       "ci-build": "https://fhir.fi/finnish-base-profiles",
       "editions": [
         {
-          "name": "STU 1 Qa-preview",
-          "ig-version": "1.0.0-rc20",
-          "package": "hl7.fhir.fi.base#1.0.0-rc20",
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.fi.base#1.0.0",
           "fhir-version": [
             "4.0.1"
           ],
-          "url": "https://hl7.fi/fhir/finnish-base-profiles/1.0-rc20"
+          "url": "https://hl7.fi/fhir/finnish-base-profiles/1.0.0"
         }
       ]
     },
@@ -7818,7 +7819,7 @@
       "ci-build": "https://fhir.fi/finnish-smart",
       "editions": [
         {
-          "name": "Release 1.0.0, STU 1",
+          "name": "STU 1",
           "ig-version": "1.0.0",
           "package": "hl7.fhir.fi.smart#1.0.0",
           "fhir-version": [

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -105,6 +105,11 @@
       "name": "HL7 Sweden",
       "url": "https://hl7.se/fhir/ig/package-feed.xml",
       "errors": "petur_valdimarsson|chorus_se"
+    },
+    {
+      "name": "HL7 Finland",
+      "url": "https://hl7.fi/fhir/package-feed.xml",
+      "errors": "mikael|sensotrend_com"
     }
   ],
   "package-restrictions": [
@@ -173,6 +178,10 @@
     {
       "mask": "hl7.fhir.ee.*",
       "feeds": [ "https://fhir.ee/packages/package-feed.xml"  ]
+    },
+    {
+      "mask": "hl7.fhir.fi.*",
+      "feeds": [ "https://hl7.fi/fhir/package-feed.xml" ]
     }
   ]
 }  

--- a/templates.json
+++ b/templates.json
@@ -14,6 +14,7 @@
 	"hl7.be.fhir.template" : "hl7-be/hl7.be.fhir.template",
 	"hl7.cda.template" : "HL7/ig-template-cda",
 	"hl7.davinci.template" : "HL7/ig-template-davinci",
+	"hl7.fi.fhir.template" : "fhir-fi/ig-template-fhir-fi",
 	"hl7.fhir.template" : "HL7/ig-template-fhir",
 	"hl7.gravity.template" : "HL7/ig-template-gravity",
 	"hl7.utg.template" : "HL7/ig-template-utg",


### PR DESCRIPTION
Add three FHIR IG's maintained by HL7 Finland:
- Finnish IG for SMART App Launch
- Finnish FHIR Base Profiles
- Finnish Scheduling

Also add a template used by the IG's, and the package feeds.