### PR TITLE
Add temporary Te Whatu Ora UAT feed

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -190,6 +190,11 @@
       "name": "IKNL",
       "url": "http://iknl.github.io/NkrIG/package-feed.xml",
       "errors": "fhir|iknl_nl"
+    },
+    {
+      "name": "Health New Zealand Te Whatu Ora FHIR Implementation Guides UAT",
+      "url": "https://fhir-ig-uat.digital.health.nz/package-feed.xml",
+      "errors": "kyle_martin|tewhatuora_govt_nz"
     }
   ],
   "package-restrictions": [


### PR DESCRIPTION
This pull request adds a temporary package feed to enable us to perform an End to End test of publishing packages to the registry. The intent is that this will later be updated to a finalised feed.