### PR TITLE
Add workflow to validate escaped unicode characters

### DIFF
--- a/.github/workflows/validate-escaped-unicode.yml
+++ b/.github/workflows/validate-escaped-unicode.yml
@@ -1,0 +1,25 @@
+name: Check for Escaped Unicode Characters
+
+on:
+  push:
+    paths:
+      - 'fhir-ig-list.json'
+  pull_request:
+    paths:
+      - 'fhir-ig-list.json'
+
+jobs:
+  check-unicode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for escaped Unicode characters
+        run: |
+          if grep -q '\\u' fhir-ig-list.json; then
+            echo "Error: Escaped Unicode characters found in fhir-ig-list.json"
+            echo "Failing lines:"
+            grep -n '\\u' fhir-ig-list.json
+            exit 1
+          else
+            echo "No escaped Unicode characters found."
+          fi


### PR DESCRIPTION
Added workflow to validate escaped unicode characters - complementing https://github.com/FHIR/ig-registry/pull/313 to ensure we don't drift in the future and let them sneak in.