### PR TITLE
Update package-feeds.json

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -192,9 +192,9 @@
       "errors": "fhir|iknl_nl"
     },
     {
-      "name": "Health New Zealand Te Whatu Ora FHIR Implementation Guides UAT",
-      "url": "https://fhir-ig-uat.digital.health.nz/package-feed.xml",
-      "errors": "kyle_martin|tewhatuora_govt_nz"
+      "name": "Health New Zealand Te Whatu Ora FHIR Implementation Guides",
+      "url": "https://fhir-ig.digital.health.nz/package-feed.xml",
+      "errors": "integration|tewhatuora_govt_nz"
     }
   ],
   "package-restrictions": [


### PR DESCRIPTION
This pull request removes the UAT testing feed, and updates it with the permanent address.

The UAT feed was previously added for initial testing in PR https://github.com/FHIR/ig-registry/pull/309

Going forward, any changes to this feed will be managed by [@daniel-thomson](https://github.com/daniel-thomson) or members of the Te Whatu Ora Health New Zealand Integration team who can be reached via the email address listed in the PR