### PR TITLE
Create registration for cds-hooks and cds-hooks-library

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7412,6 +7412,57 @@
           "url" : "http://smart.who.int/icvp/0.1.0"
         }
       ]
+    },
+    {
+      "name" : "CDS Hooks",
+      "category" : "CDS",
+      "npm-name" : "hl7.fhir.uv.cds-hooks",
+      "description" : "CDS Hooks describes a \"hook\"-based pattern for invoking decision support from within a clinician's workflow.",
+      "authority" : "HL7",
+      "product" : ["fhir"],
+      "country" : "uv",
+      "language" : ["en"],
+      "history" : "http://hl7.org/fhir/us/cds-hooks/history.html",
+      "canonical" : "http://hl7.org/fhir/us/cds-hooks",
+      "ci-build" : "http://build.fhir.org/ig/HL7/cds-hooks",
+      "editions" : [
+        {
+          "name" : "STU 1",
+          "ig-version" : "1.0.0",
+          "package" : "hl7.fhir.cds-hooks#1.0.0",
+          "fhir-version" : ["4.0.1"],
+          "url" : "http://cds-hooks.hl7.org/1.0/"
+        },
+        {
+          "name" : "STU 2",
+          "ig-version" : "2.0.1",
+          "package" : "hl7.fhir.cds-hooks#2.0.1",
+          "fhir-version" : ["4.0.1"],
+          "url" : "http://hl7.org/fhir/us/cds-hooks/STU2"
+        }
+      ]
+    },
+    {
+      "name" : "CDS Hooks Library",
+      "category" : "CDS",
+      "npm-name" : "hl7.fhir.uv.cds-hooks-library",
+      "description" : "CDS Hooks describes a \"hook\"-based pattern for invoking decision support from within a clinician's workflow. The CDS Hook Library defines hooks standardized across the community.",
+      "authority" : "HL7",
+      "product" : ["fhir"],
+      "country" : "uv",
+      "language" : ["en"],
+      "history" : "http://hl7.org/fhir/us/cds-hooks-library/history.html",
+      "canonical" : "http://hl7.org/fhir/us/cds-hooks-library",
+      "ci-build" : "http://build.fhir.org/ig/HL7/cds-hooks-library",
+      "editions" : [
+        {
+          "name" : "STU 2",
+          "ig-version" : "2.0.1",
+          "package" : "hl7.fhir.cds-hooks#2.0.1",
+          "fhir-version" : ["4.0.1"],
+          "url" : "http://hl7.org/fhir/us/cds-hooks/STU2"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
As part of an errata publication, the CDS workgroup is performing an "uplift" of the CDS Hooks specification to use the HL7 FHIR template for an implementation guide. In this uplift, the CDS Hooks specification is being split into two effective implementation guides (so that the defined hooks can be updated and balloted more frequently than the base specification):
- CDS Hooks (the base CDS Hooks IG)
- CDS Hooks Library (defined CDS Hooks)

The most recent version of these IGs will be 2.0.1, as these are not new specifications, but rather splitting the existing specification into two specifications. The base CDS Hooks IG will retain the history of the previous CDS Hooks Specification.