### PR TITLE
fix mask to reflect correct id

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -227,7 +227,7 @@
       "feeds": [ "http://hl7.org.au/fhir/package-feed.xml" ]
     },
     {
-      "mask": "hl7.fhir.nz.*",
+      "mask": "fhir.org.nz.ig.*",
       "feeds": [ "https://github.com/HL7NZ/hl7-nz-package-feed/blob/main/package-feed.xml?raw=true" ]
     },
     {


### PR DESCRIPTION
Noticed we're getting an 'prohibited source' error for the NZ base package: 
![image](https://github.com/user-attachments/assets/92ac4151-faef-43f1-abc2-a4e880722dc8)

It looks like the id of this package is matching the fhir.* mask near the bottom, and not the NZ HL7 one. Have updated our mask to match the id NZ base is using (I think it got changed early on from what was here), which should fix this error. Missed this in the original PR sorry. 

 