### PR TITLE
Support HL7 CA terminology

### DIFF
--- a/hl7-ca-tx-servers.json
+++ b/hl7-ca-tx-servers.json
@@ -1,0 +1,25 @@
+{
+  "formatVersion": "1",
+  "description": "HL7 Canada's list of published terminology servers",
+  "servers": [
+    {
+      "code": "hl7-ca",
+      "name": "Canada Health Infoway Terminology Server",
+      "access_info": "This server requires an API Key - see https://infocentral.infoway-inforoute.ca/en/tools/standards-tools/terminology-server",
+      "url": "https://terminologystandardsservice.ca/tx/fhir",
+      "authoritative": [
+        "http://snomed.info/sct|http://snomed.info/sct/20611000087101*",
+        "https://fhir.infoway-inforoute.ca/CodeSystem*"
+      ],
+      "authoritative-valuesets": [
+        "https://fhir.infoway-inforoute.ca/ValueSet*"
+      ],
+      "fhirVersions": [
+        {
+          "version": "R4",
+          "url": "https://terminologystandardsservice.ca/tx/fhir"
+        }
+      ]
+    }
+  ]
+}

--- a/tx-servers.json
+++ b/tx-servers.json
@@ -1,22 +1,32 @@
 {
-  "formatVersion" : "1",
-  "description" : "This JSON-5 file contains a list of the lists of terminology servers available for use across the FHIR tooling eco-system",
-  "user-warning" : "The FHIR Tooling eco-system exists to support design time and publication usage. It is not intended to support production use, and should not be used in operational systems",
-  "documentation" : "See https://github.com/FHIR/ig-registry/blob/master/tx-registry-doco.md",
-  "registries" : [{
-    "code" : "hl7",
-    "name" : "HL7 Terminology Services",
-    "authority" : "Published by HL7",
-    "url" : "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-tx-servers.json"
-  },{
-    "code" : "hl7-au",
-    "name" : "HL7 Australia Terminology Services",
-    "authority" : "Published by HL7 Australia",
-    "url" : "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-au-tx-servers.json"
-  },{
-    "code" : "hl7-fr",
-    "name" : "HL7 France Terminology Services",
-    "authority" : "Published by HL7 France",
-    "url" : "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-fr-tx-servers.json"
-  }]
+  "formatVersion": "1",
+  "description": "This JSON-5 file contains a list of the lists of terminology servers available for use across the FHIR tooling eco-system",
+  "user-warning": "The FHIR Tooling eco-system exists to support design time and publication usage. It is not intended to support production use, and should not be used in operational systems",
+  "documentation": "See https://github.com/FHIR/ig-registry/blob/master/tx-registry-doco.md",
+  "registries": [
+    {
+      "code": "hl7",
+      "name": "HL7 Terminology Services",
+      "authority": "Published by HL7",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-tx-servers.json"
+    },
+    {
+      "code": "hl7-au",
+      "name": "HL7 Australia Terminology Services",
+      "authority": "Published by HL7 Australia",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-au-tx-servers.json"
+    },
+    {
+      "code": "hl7-ca",
+      "name": "HL7 Canada Terminology Services",
+      "authority": "Published by HL7 Canada/\u2008Canada Health Infoway",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-ca-tx-servers.json"
+    },
+    {
+      "code": "hl7-fr",
+      "name": "HL7 France Terminology Services",
+      "authority": "Published by HL7 France",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-fr-tx-servers.json"
+    }
+  ]
 }


### PR DESCRIPTION
Added HL7 Canada entry to tx servers list and config file for Canada Health Infoway terminology server