### PR TITLE
Enhance package feeds for central terminology server in Germany

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -230,6 +230,11 @@
       "name": "MINSAL CHILE NID",
       "url": "https://interoperabilidad.minsal.cl/fhir/ig/nid/package-feed.xml",
       "errors": "Jorge_Mansilla|MINSAL_NID"
+    },
+    {
+      "name": "BfArM FHIR Packages (Terminologies)",
+      "url": "https://terminologien.bfarm.de/feeds/package-feed.xml",
+      "errors": "zts|gematik_de"
     }   
   ],
   "package-restrictions": [
@@ -334,6 +339,10 @@
     {
       "mask": "dk.ehealth.sundhed.fhir.ig.*",
       "feeds": [ "https://ehealth.sundhed.dk/package-feed.xml" ]
+    },
+    {
+      "mask": "bfarm.terminologies.*",
+      "feeds": [ "https://terminologien.bfarm.de/feeds/package-feed.xml" ]
     }
   ]
 }

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -341,7 +341,7 @@
       "feeds": [ "https://ehealth.sundhed.dk/package-feed.xml" ]
     },
     {
-      "mask": "bfarm.terminologie.*",
+      "mask": "bfarm.terminologien.*",
       "feeds": [ "https://terminologien.bfarm.de/feeds/package-feed.xml" ]
     }
   ]

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -341,7 +341,7 @@
       "feeds": [ "https://ehealth.sundhed.dk/package-feed.xml" ]
     },
     {
-      "mask": "bfarm.terminologies.*",
+      "mask": "bfarm.terminologie.*",
       "feeds": [ "https://terminologien.bfarm.de/feeds/package-feed.xml" ]
     }
   ]

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -247,9 +247,9 @@
       "errors": "aachik|trimoz_com"
     },
     {
-    "name": "BfArM FHIR Packages (Terminologies)",
-    "url": "https://terminologien.bfarm.de/feeds/package-feed.xml",
-    "errors": "zts|gematik_de"
+      "name": "BfArM FHIR Packages (Terminologies)",
+      "url": "https://terminologien.bfarm.de/feeds/package-feed.xml",
+      "errors": "zts|gematik_de"
     } 
   ],
   "package-restrictions": [


### PR DESCRIPTION
This pull request contains enhancements to the package feed configuration in relation to the central terminology server in Germany.  The changes include:

- Extension of package.json with additional feed definitions and package restrictions

These updates aim to streamline package distribution and improve accessibility for stakeholders relying on the central terminology server in Germany. Please review the modifications and let me know if any adjustments are needed.