### PR TITLE
add terminology server from HL7 Switzerland

### DIFF
--- a/hl7-ch-tx-servers.json
+++ b/hl7-ch-tx-servers.json
@@ -1,0 +1,25 @@
+{
+  "formatVersion": "1",
+  "description": "HL7 Switzerland list of published terminology servers",
+  "servers": [
+    {
+      "code": "hl7-ch",
+      "name": "HL7 Switzerland Terminology Server",
+      "access_info": "Open",
+      "url": "http://tx.fhir.ch",
+      "authoritative": [
+        "http://fhir.ch/ig/ch-*",
+        "http://snomed.info/sct|http://snomed.info/sct/2011000195101/version/20241207*"
+      ],
+      "authoritative-valuesets": [
+        "http://fhir.ch/ig/ch-*"
+      ],
+      "fhirVersions": [
+        {
+          "version": "R4",
+          "url": "http://tx.fhir.ch/r4"
+        }
+      ]
+    }
+  ]
+}

--- a/tx-servers.json
+++ b/tx-servers.json
@@ -39,6 +39,12 @@
       "name": "HL7 Europe Terminology Services",
       "authority": "Published by HL7 Europe",
       "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-eu-tx-servers.json"
+    },
+    {
+      "code": "hl7-ch",
+      "name": "HL7 Switzerland Terminology Server",
+      "authority": "Published by HL7 Switzerland",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-ch-tx-servers.json"
     }
   ]
 }


### PR DESCRIPTION
We have set up and terminology server from HL7 Switzerland to promote the terminologies from switzerland and also the actual swiss extension of snomed ct.