### PR TITLE
Add term.tehik.ee tx

### DIFF
--- a/hl7-ee-tx-servers.json
+++ b/hl7-ee-tx-servers.json
@@ -1,0 +1,25 @@
+{
+    "formatVersion": "1",
+    "description": "Estonian list of published terminology servers",
+    "servers": [
+      {
+        "code": "tehik-ee",
+        "name": "TEHIK Terminology Server",
+        "access_info": "Open",
+        "url": "https://term.tehik.ee/fhir",
+        "authoritative": [
+          "https://fhir.ee/CodeSystem*",
+          "http://snomed.info/sct|http://snomed.info/sct/11000181102*"
+        ],
+        "authoritative-valuesets": [
+          "https://fhir.ee/ValueSet*"
+        ],
+        "fhirVersions": [
+          {
+            "version": "R5",
+            "url": "https://term.tehik.ee/fhir"
+          }        
+        ]
+      }
+    ]
+  }

--- a/tx-servers.json
+++ b/tx-servers.json
@@ -45,6 +45,12 @@
       "name": "HL7 Switzerland Terminology Server",
       "authority": "Published by HL7 Switzerland",
       "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-ch-tx-servers.json"
+    },
+    {
+      "code": "tehik-ee",
+      "name": "TEHIK Terminology Server",
+      "authority": "Published by Estonian Health and Welfare Information Systems Centre (TEHIK)",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-ee-tx-servers.json"
     }
   ]
 }


### PR DESCRIPTION
Added Estonian de facto national terminology server run by TEHIK (Estonian SNOMED NRC). 
Terminology server uses Ontoserver R5 version, and is an authoritative source for Estonian SNOMED extension and health information (eco)system terminology.