### PR TITLE
Update templates.json

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -20,5 +20,7 @@
 	"hl7.utg.template" : "HL7/ig-template-utg",
 	"ihe.fhir.template" : "IHE/ihe-ig-template",
 	"openhie.fhir.template" : "openhie/openhie-ig-template",
-	"who.fhir.template" : "WorldHealthOrganization/smart-ig"
+	"who.fhir.template" : "WorldHealthOrganization/smart-ig",
+	"hl7.fhir.cr.template": "https://fhir.hl7.or.cr/template"
 }
+


### PR DESCRIPTION
Registro del template oficial de Costa Rica: hl7.fhir.cr.template
Canonical: https://fhir.hl7.or.cr/template