### PR TITLE
Add Uzbekistan Digital Health Platform

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -265,6 +265,11 @@
       "name": "Taiwan NHI-MOHW FHIR Packages",
       "url": "https://nhicore.nhi.gov.tw/packages/package-feed.xml",
       "errors": "TWNHI_FHIR|nhi_gov_tw"
+    },
+	{
+      "name": "DHP Uzbekistan",
+      "url": "https://vadi2.github.io/DHP-temp/package-feed.xml",
+      "errors": "fhir|vadimperetok.in"
     }
   ],
   "package-restrictions": [
@@ -401,6 +406,7 @@
     {
       "mask": "tw.gov.mohw.*",
       "feeds": [ "https://twcore.mohw.gov.tw/ig/packages/package-feed.xml", "https://nhicore.nhi.gov.tw/packages/package-feed.xml" ]
-    }
+    },
   ]
 }
+

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -406,7 +406,8 @@
     {
       "mask": "tw.gov.mohw.*",
       "feeds": [ "https://twcore.mohw.gov.tw/ig/packages/package-feed.xml", "https://nhicore.nhi.gov.tw/packages/package-feed.xml" ]
-    },
+    }
   ]
 }
+
 


### PR DESCRIPTION
Added Uzbekistan's DHP package feed. The location is temporary and subject to change in the future, but we need a FHIR Package now in order to build dependant IGs.