### PR TITLE
Update Uzbekistan DHP feed URL

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -273,7 +273,7 @@
     },
 	{
       "name": "DHP Uzbekistan",
-      "url": "https://vadi2.github.io/DHP-temp/package-feed.xml",
+      "url": "https://vadimperetok.in/DHP-temp/package-feed.xml",
       "errors": "fhir|vadimperetok.in"
     }
   ],
@@ -418,3 +418,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
The feed had a redirect on it and the package crawler considers redirects to be unrecorable errors, fixing the URL.

```
Error: Server responds with: MovedPermanently
Done. Meta feed processed.
```