### PR TITLE
update HL7 Germany package feed URL to new publication feed

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -118,7 +118,7 @@
     },
     {
       "name": "HL7 Germany",
-      "url": "https://github.com/hl7germany/hl7-de-package-feed/blob/main/package-feed.xml?raw=true",
+      "url": "https://ig.fhir.de/igs/publication-feed.xml",
       "errors": "cto|hl7_de"
     },
     {


### PR DESCRIPTION
We recently switched to IG Publisher based IGs and publishing process. This PR updates the german package feed to its new url.