### PR TITLE
fix: updated german package feed to the correct url

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -118,7 +118,7 @@
     },
     {
       "name": "HL7 Germany",
-      "url": "https://ig.fhir.de/igs/publication-feed.xml",
+      "url": "https://ig.fhir.de/igs/package-feed.xml",
       "errors": "cto|hl7_de"
     },
     {


### PR DESCRIPTION
my last PR changed the german package url to the publication feed, instead of the package feed.
This PR fixes this error.