### PR TITLE
Add Bangladesh Core FHIR IG package feed

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -290,6 +290,11 @@
       "name": "CSIRO FHIR Implementation Guides",
       "url": "https://starsapi.csiro.au/fhir-ig/package-feed.xml",
       "errors": "stars-support|csiro_au"
+    },
+	{
+      "name": "DGHS Bangladesh",
+      "url": "https://git.dghs.gov.bd/gitadmin/BD-Core-FHIR-IG/package-feed.xml",
+      "errors": "digitalhealth|dghs_gov_bd"
     }
   ],
   "package-restrictions": [
@@ -433,3 +438,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
This PR adds the Bangladesh Core FHIR Implementation Guide package feed to the HL7 IG registry.

Publisher: Directorate General of Health Services, Ministry of Health and Family Welfare, Bangladesh

Package ID: bd.fhir.core

Feed URL: https://git.dghs.gov.bd/gitadmin/BD-Core-FHIR-IG/package-feed.xml

First Release: 0.2.0 (draft)

Purpose: To make the Bangladesh Core FHIR IG discoverable globally through the HL7 package registry.