### PR TITLE
Add Annotate MD package feed and IG registration

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -1,9542 +1,12808 @@
 {
-  "guides" : [{
-    "name" : "US Core",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.us.core",
-    "description" : "Base US national implementation guide",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "implementations" : [{
-      "name" : "Test Server",
-      "type" : "server",
-      "url" : "http://test.fhir.org"
+  "guides": [
+    {
+      "name": "Advance Care Planning (PZP)",
+      "category": "Care Management",
+      "npm-name": "iknl.fhir.r4.pzp",
+      "description": "This implementation guide supports the Advance Care Planning (ACP) information standard (Dutch: Proactieve Zorgplanning) and is intended for use within the palliative care domain in the Netherlands.",
+      "authority": "IKNL",
+      "country": "nl",
+      "history": "https://api.iknl.nl/docs/pzp/r4/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://api.iknl.nl/docs/pzp/r4",
+      "ci-build": "http://build.fhir.org/ig/IKNL/PZP-FHIR-R4/branches/develop",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0-rc2",
+          "package": "iknl.fhir.r4.pzp#1.0.0-rc2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://api.iknl.nl/docs/pzp/r4/1.0.0-rc2"
+        }
+      ]
     },
     {
-      "name" : "Source Code",
-      "type" : "source",
-      "url" : "http://github.com/HealthIntersections/fhirserver"
-    }],
-    "history" : "http://hl7.org/fhir/us/core/history.html",
-    "canonical" : "http://hl7.org/fhir/us/core",
-    "ci-build" : "http://build.fhir.org/ig/HL7/US-Core",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 42,
-      "extensions" : 5,
-      "operations" : 1,
-      "valuesets" : 31,
-      "codeSystems" : 4,
-      "examples" : 111
+      "name": "Advance Care Planning (PZP)",
+      "category": "Care Management",
+      "npm-name": "iknl.fhir.stu3.pzp",
+      "description": "This implementation guide supports the Advance Care Planning (ACP) information standard (Dutch: Proactieve Zorgplanning) and is intended for use within the palliative care domain in the Netherlands.",
+      "authority": "IKNL",
+      "country": "nl",
+      "history": "https://api.iknl.nl/docs/pzp/stu3/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://api.iknl.nl/docs/pzp/stu3",
+      "ci-build": "http://build.fhir.org/ig/IKNL/PZP-FHIR-STU3/branches/develop",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0-rc2",
+          "package": "iknl.fhir.stu3.pzp#1.0.0-rc2",
+          "fhir-version": [
+            "3.0.2"
+          ],
+          "url": "https://api.iknl.nl/docs/pzp/stu3/1.0.0-rc2"
+        }
+      ]
     },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU9 Ballot",
-      "ig-version" : "9.0.0-ballot",
-      "package" : "hl7.fhir.us.core#9.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/core/2026Jan"
-    }]
-  },
-  {
-    "name" : "AU Base",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.au.base",
-    "description" : "AU Base implementation guide provides support for the use of FHIR®© in an Australian context.",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "au",
-    "language" : ["en"],
-    "history" : "http://hl7.org.au/fhir/history.html",
-    "canonical" : "http://hl7.org.au/fhir",
-    "ci-build" : "http://build.fhir.org/ig/hl7au/au-fhir-base",
-    "editions" : [{
-      "name" : "Working Standard",
-      "ig-version" : "6.0.0",
-      "package" : "hl7.fhir.au.base#6.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org.au/fhir/6.0.0"
-    }],
-    "analysis" : {
-      "error" : "JsonObject"
+    {
+      "name": "Adverse Event Clinical Research",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.ae-research-ig",
+      "description": "This IG is for the clinical research setting. It defines the data elements needed to support the workflow for collecting and reporting serious and non-serious adverse events in clinical research to meet the need for regulatory submission requirements.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ae-research-ig/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ae-research-ig",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-ae-research-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.uv.ae-research-ig#1.0.1",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/ae-research-ig/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Adverse Event Clinical Research R4 Backport",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.ae-research-backport-ig",
+      "description": "This IG is for the clinical research setting. It defines the data elements needed to support the workflow for collecting and reporting serious and non-serious adverse events in clinical research to meet the need for regulatory submission requirements.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ae-research-backport-ig/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ae-research-backport-ig",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-ae-research-backport-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.uv.ae-research-backport-ig#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/ae-research-backport-ig/STU1"
+        }
+      ]
+    },
+    {
+      "name": "AI Transparency on FHIR",
+      "category": "AI",
+      "npm-name": "hl7.fhir.uv.aitransparency",
+      "description": "Healthcare systems increasingly use artificial intelligence to process patient data. This IG defines a standard way to communicate when and how AI was involved to downstream users. This track enables participants to implement transparent labeling and documentation of AI usage in healthcare data exchanges, ensuring clinicians and patients can make informed decisions about AI-influenced information",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/aitransparency/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/aitransparency",
+      "ci-build": "http://build.fhir.org/ig/HL7/aitransparency-ig/branches/main/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.aitransparency#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/aitransparency/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "Animal terapeuta (n\u00e3o humano)",
+      "category": "Research",
+      "npm-name": "animal.terapeuta",
+      "description": "Cadastro de animais terapeutas visando a facilidade de localiza\u00e7\u00e3o deles pelas habilidades.",
+      "authority": "CGIS (UFG) (BR)",
+      "country": "br",
+      "history": "https://fhir.fabrica.inf.ufg.br/ig/history.html",
+      "language": [
+        "pt"
+      ],
+      "canonical": "https://fhir.fabrica.inf.ufg.br/ig",
+      "ci-build": "https://fhir.fabrica.inf.ufg.br/ig",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.1.2",
+          "package": "animal.terapeuta#0.1.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://fhir.fabrica.inf.ufg.br/ig"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Application Data Exchange Assessment Framework and Functional Requirements for Mobile Health",
+      "category": "Personal Healthcare",
+      "npm-name": "hl7.fhir.uv.mhealth-framework",
+      "description": "Document the functional requirements that can be used to assess devices, applications, and FHIR profiles to ensure that the essential data needed for clinical, patient and research uses is present in communications between applications",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/mhealth-framework/history.html",
+      "canonical": "http://hl7.org/fhir/uv/mhealth-framework",
+      "ci-build": "http://hl7.org/fhir/uv/mhealth-framework",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 2
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.uv.mhealth-framework#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/mhealth-framework/2020May"
+        }
+      ]
+    },
+    {
+      "name": "Argonaut Clinical Notes Implementation Guide",
+      "category": "EHR Access",
+      "npm-name": "argonaut.us.clinicalnotes",
+      "description": "This implementation guide provides implementers with FHIR profiles and guidance to create, use, and share Clinical Notes",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://fhir.org/guides/argonaut/clinicalnotes/history.html",
+      "canonical": "http://fhir.org/guides/argonaut/clinicalnotes",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/clinicalnotes",
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0",
+          "package": "argonaut.us.clinicalnotes#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.org/guides/argonaut/clinicalnotes/1.0.0"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id argonaut.us.clinicalnotes#1.0.0"
+      },
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Argonaut Clinical Notes Implementation Guide",
+      "category": "EHR Access",
+      "npm-name": "fhir.argonaut.clinicalnotes",
+      "description": "This implementation guide provides implementers with FHIR profiles and guidance to create, use, and share Clinical Notes",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://fhir.org/guides/argonaut/clinicalnotes/history.html",
+      "canonical": "http://fhir.org/guides/argonaut/clinicalnotes",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/clinicalnotes",
+      "language": [
+        "en"
+      ],
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0",
+          "package": "fhir.argonaut.clinicalnotes#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.org/guides/argonaut/clinicalnotes/1.0.0"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "profiles": 2,
+        "valuesets": 3,
+        "codeSystems": 1
+      }
+    },
+    {
+      "name": "Argonaut Data Query",
+      "category": "EHR Access",
+      "npm-name": "fhir.argonaut.r2",
+      "description": "This implementation guide is based upon DSTU2 FHIR standard and covers the US EHR data access for the ONC Common Clinical Data Set and retrieval of static documents",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://www.fhir.org/guides/argonaut/r2/history.html",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/data-query",
+      "canonical": "http://fhir.org/guides/argonaut/r2",
+      "editions": [
+        {
+          "name": "First Release",
+          "ig-version": "1.0.0",
+          "package": "fhir.argonaut.r2#1.0.0",
+          "fhir-version": [
+            "1.0.2"
+          ],
+          "url": "http://fhir.org/guides/argonaut/r2/1.0"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 17,
+        "extensions": 5,
+        "operations": 1,
+        "valuesets": 25
+      }
+    },
+    {
+      "name": "Argonaut Provider Directory",
+      "category": "Administration",
+      "npm-name": "fhir.argonaut.pd",
+      "description": "This implementation guide is based upon STU3 FHIR standard and outlines the key data elements for any provider directory and basic query guidance. The components developed in this guide are intended to provide a foundation for a central or distributed Provider or Healthcare Directory",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://www.fhir.org/guides/argonaut/pd/history.html",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/provider-directory",
+      "canonical": "http://fhir.org/guides/argonaut/pd",
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0",
+          "package": "fhir.argonaut.pd#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.org/guides/argonaut/pd/release1"
+        }
+      ],
+      "analysis": {
+        "error": "Unknown FHIRVersion code 'STU3'"
+      }
+    },
+    {
+      "name": "Argonaut Questionnaire Implementation Guide",
+      "category": "EHR Access",
+      "npm-name": "argonaut.us.questionnaire",
+      "description": "This implementation guide provides implementers with FHIR RESTful APIs and guidance to create, use and share between organizations standard assessment forms and the assessment responses",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://fhir.org/guides/argonaut/questionnaire/history.html",
+      "canonical": "http://fhir.org/guides/argonaut/questionnaire",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/questionnaire",
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0",
+          "package": "argonaut.us.questionnaire#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.org/guides/argonaut/questionnaire/1.0.0"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id argonaut.us.questionnaire#1.0.0"
+      },
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Argonaut Questionnaire Implementation Guide",
+      "category": "EHR Access",
+      "npm-name": "fhir.argonaut.questionnaire",
+      "description": "Thi IG provides guidance to support interchange of simple forms based on the Questionnaire and QuestionnaireResponse resources: it provides implementers with FHIR RESTful APIs and guidance to create, use and share between organizations standard assessment forms and the assessment responses",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://fhir.org/guides/argonaut/questionnaire/history.html",
+      "canonical": "http://fhir.org/guides/argonaut/questionnaire",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/questionnaire",
+      "language": [
+        "en"
+      ],
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.0.0",
+          "package": "fhir.argonaut.questionnaire#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.org/guides/argonaut/questionnaire/1.0.0"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "questionnaire": true,
+        "profiles": 4,
+        "extensions": 5,
+        "operations": 1
+      }
+    },
+    {
+      "name": "Argonaut Scheduling",
+      "category": "Administration",
+      "npm-name": "fhir.argonaut.scheduling",
+      "description": "This implementation guide is based upon STU3 FHIR standard and provides FHIR RESTful APIs and guidance for access to and booking of appointments for patients by both patient and practitioner end users",
+      "authority": "Argonaut (US)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://www.fhir.org/guides/argonaut/scheduling/history.html",
+      "ci-build": "http://build.fhir.org/ig/argonautproject/scheduling",
+      "canonical": "http://fhir.org/guides/argonaut/scheduling",
+      "editions": [
+        {
+          "name": "First Release",
+          "ig-version": "1.0.0",
+          "package": "fhir.argonaut.scheduling#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.org/guides/argonaut/scheduling/release1"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "financials": true,
+        "scheduling": true,
+        "profiles": 7,
+        "extensions": 4,
+        "operations": 4,
+        "valuesets": 7,
+        "codeSystems": 3
+      }
+    },
+    {
+      "name": "At-Home In-Vitro Test Report",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.fhir.us.home-lab-report",
+      "description": "This Implementation Guide describes a framework for use for transmitting At-Home Point-of-Care lab test results to local, state, territorial and federal health agencies. This version also contains workflow description and profiles and vocabulary for transmitting Covid-At-Home tests.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/home-lab-report/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/home-lab-report",
+      "ci-build": "http://build.fhir.org/ig/HL7/home-lab-report",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.home-lab-report#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/home-lab-report/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.home-lab-report#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/home-lab-report/STU1"
+        }
+      ]
+    },
+    {
+      "name": "AU Base",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.au.base",
+      "description": "AU Base implementation guide provides support for the use of FHIR\u00ae\u00a9 in an Australian context.",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "au",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org.au/fhir/history.html",
+      "canonical": "http://hl7.org.au/fhir",
+      "ci-build": "http://build.fhir.org/ig/hl7au/au-fhir-base",
+      "editions": [
+        {
+          "name": "Working Standard",
+          "ig-version": "6.0.0",
+          "package": "hl7.fhir.au.base#6.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org.au/fhir/6.0.0"
+        }
+      ],
+      "analysis": {
+        "error": "JsonObject"
+      }
+    },
+    {
+      "name": "AU Core",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.au.core",
+      "description": "AU Core implementation guide provides support for the use of FHIR\u00ae\u00a9 in an Australian context, and sets the minimum expectations on FHIR resources to support conformance and implementation in systems.",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "au",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org.au/fhir/core/history.html",
+      "canonical": "http://hl7.org.au/fhir/core",
+      "ci-build": "http://build.fhir.org/ig/hl7au/au-fhir-core",
+      "editions": [
+        {
+          "name": "Working Standard",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.au.core#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org.au/fhir/core/2.0.0"
+        }
+      ],
+      "analysis": {
+        "error": "JsonObject"
+      }
+    },
+    {
+      "name": "AU eRequesting",
+      "category": "eRequesting",
+      "npm-name": "hl7.fhir.au.ereq",
+      "description": "AU eRequesting is provided to support the use of HL7\u00ae FHIR\u00ae\u00a9 for diagnostic requesting in an Australian context, and sets the minimum expectations on FHIR resources to support conformance and implementation in systems.",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "au",
+      "language": [
+        "en"
+      ],
+      "history": "https://hl7.org.au/fhir/ereq/history.html",
+      "canonical": "http://hl7.org.au/fhir/ereq",
+      "ci-build": "https://build.fhir.org/ig/hl7au/au-fhir-erequesting",
+      "editions": [
+        {
+          "name": "Working Standard",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.au.ereq#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.org.au/fhir/ereq/1.0.0"
+        }
+      ],
+      "analysis": {
+        "error": "JsonObject"
+      }
+    },
+    {
+      "name": "AU Patient Summary",
+      "category": "Patient Summary",
+      "npm-name": "hl7.fhir.au.ps",
+      "description": "AU Patient Summary (AU PS) is provided to support the use of patient summaries in FHIR\u00ae\u00a9 in an Australian context. It is based on IPS and AU Core, setting the minimum conformance expectations for implementing support for AU PS documents in systems.",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "au",
+      "language": [
+        "en"
+      ],
+      "history": "https://hl7.org.au/fhir/ps/history.html",
+      "canonical": "http://hl7.org.au/fhir/ps",
+      "ci-build": "https://build.fhir.org/ig/hl7au/au-fhir-ps",
+      "editions": [
+        {
+          "name": "Ballot for Working Standard",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.au.ps#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.org.au/fhir/ps/1.0.0-ballot"
+        }
+      ],
+      "analysis": {
+        "error": "JsonObject"
+      }
+    },
+    {
+      "name": "Audit Trail Consumption (CH-ATC)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.atc",
+      "description": "National Integration Profile for the Swiss Electronic Patient Record",
+      "authority": "FOPH",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-atc/history.html",
+      "canonical": "http://fhir.ch/ig/ch-atc",
+      "ci-build": "http://build.fhir.org/ig/ahdis/ch-atc/index.html",
+      "editions": [
+        {
+          "ig-version": "3.3.0",
+          "name": "2022-12-28",
+          "package": "ch.fhir.ig.ch-atc#3.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-atc/index.html"
+        },
+        {
+          "name": "Release 24.6.2019",
+          "ig-version": "1.2.0",
+          "package": "ch.fhir.ig.ch-atc#1.2.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-atc/1.2.0/index.html"
+        }
+      ]
+    },
+    {
+      "name": "Austrian Patient Summary (R4)",
+      "category": "Patient Summary",
+      "npm-name": "hl7.at.fhir.elga.aps.r4",
+      "description": "The FHIR\u00ae implementation guide Austrian Patient Summary is derived from the HL7\u00ae Austria FHIR\u00ae Core implementation guide and ensures conformity with the International Patient Summary (IPS).",
+      "authority": "ELGA GmbH",
+      "country": "at",
+      "history": "https://fhir.hl7.at/elga/aps/r4/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://fhir.hl7.at/elga/aps/r4",
+      "ci-build": "http://build.fhir.org/ig/HL7Austria/ELGA-AustrianPatientSummary-R4",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.at.fhir.elga.aps.r4#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://fhir.hl7.at/elga/aps/r4/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Bangladesh FHIR Implementation Guide - Core Profiles",
+      "category": "National Base",
+      "npm-name": "bd.fhir.core",
+      "description": "National base profiles, CodeSystems, and ValueSets for Bangladesh, developed and maintained by the Directorate General of Health Services (DGHS), Ministry of Health and Family Welfare.",
+      "authority": "DGHS Bangladesh",
+      "product": [
+        "fhir"
+      ],
+      "country": "bd",
+      "history": "https://fhir.dghs.gov.bd/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://fhir.dghs.gov.bd/core",
+      "ci-build": "https://fhir.dghs.gov.bd/core",
+      "editions": [
+        {
+          "name": "Draft 0.2.0",
+          "ig-version": "0.2.0",
+          "package": "bd.fhir.core#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://fhir.dghs.gov.bd/core"
+        }
+      ]
+    },
+    {
+      "name": "Base openEHR specification",
+      "category": "Infrastructure",
+      "npm-name": "openehr.base",
+      "description": "openEHR Base specification",
+      "authority": "openEHR",
+      "country": "uv",
+      "history": "http://openehr.org/fhir/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://openehr.org/fhir",
+      "ci-build": "http://build.fhir.org/ig/openehr-fhir/base-spec",
+      "product": [
+        "openehr"
+      ],
+      "editions": [
+        {
+          "name": "Release Informative",
+          "ig-version": "0.1.0-snapshot",
+          "package": "openehr.base#0.1.0-snapshot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://fhir.org/guides/openehr/base/0.1.0-snapshot"
+        }
+      ]
+    },
+    {
+      "name": "Basic National Terminology for Costa Rica",
+      "category": "Terminology",
+      "npm-name": "hl7.fhir.cr.terminology",
+      "description": "This implementation guide defines the FHIR terminology resources used by the HL7 Costa Rica Initiative.",
+      "authority": "HL7 Initiative in Costa Rica",
+      "country": "cr",
+      "history": "https://hl7.or.cr/fhir/terminology/history.html",
+      "language": [
+        "es"
+      ],
+      "canonical": "https://hl7.or.cr/fhir/terminology",
+      "ci-build": "http://build.fhir.org/ig/HL7-cr/terminology",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Draft 0.0.1",
+          "ig-version": "0.0.1-ballot",
+          "package": "hl7.fhir.cr.terminology#0.0.1-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://hl7.or.cr/fhir/terminology/0.0.1-ballot"
+        }
+      ]
+    },
+    {
+      "name": "Basisgegevensset Zorg || Patient Summary",
+      "npm-name": "nictiz.fhir.nl.stu3.zib2017",
+      "category": "Patient Summary",
+      "description": "The Basisgegevensset Zorg, aka BgZ, is the minimum set of patient data that is important for continuity of care and is relevant irrespective of specialism, patient conditions and type of physicians. This set of patient data is recorded comparatively by all healthcare providers. This facilitates information exchange. The BgZ has been made consistent with the European Patient Summary.",
+      "authority": "Nictiz (NL)",
+      "product": [
+        "fhir"
+      ],
+      "country": "nl",
+      "language": [
+        "nl",
+        "en"
+      ],
+      "history": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2019.01_OntwerpBGZ_2017#Release_notes",
+      "canonical": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2019.01_OntwerpBGZ_2017",
+      "ci-build": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:Vdraft_OntwerpBGZ_2017",
+      "editions": [
+        {
+          "name": "Normative - MMVN 3",
+          "ig-version": "2.1.3",
+          "package": "nictiz.fhir.nl.stu3.zib2017#2.1.3",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2019.01_OntwerpBGZ_2017#Use_case_1:_Raadplegen_Basisgegevensset_Zorg_in_persoonlijke_gezondheidsomgeving"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "profiles": 144,
+        "extensions": 70,
+        "valuesets": 261
+      }
+    },
+    {
+      "name": "Basisprofil DE",
+      "category": "National Base",
+      "npm-name": "basisprofil.de",
+      "description": "German Base Profiles",
+      "authority": "HL7 Deutschland",
+      "product": [
+        "fhir"
+      ],
+      "country": "de",
+      "history": "http://ig.fhir.de/basisprofile-de",
+      "canonical": "http://fhir.de",
+      "ci-build": "https://simplifier.net/Basisprofil-DE-R4",
+      "language": [
+        "de"
+      ],
+      "editions": [
+        {
+          "name": "STU3",
+          "ig-version": "0.2.30",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "package": "basisprofil.de#0.2.30",
+          "url": "http://ig.fhir.de/basisprofile-de/0.2.30"
+        },
+        {
+          "name": "R4",
+          "ig-version": "0.9.1-alpha2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "package": "de.basisprofil.r4#0.9.1-alpha2",
+          "url": "https://simplifier.net/guide/basisprofil-de-r4/home"
+        }
+      ],
+      "analysis": {
+        "error": "no core dependency or FHIR Version found in the Package definition",
+        "content": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 17,
+        "extensions": 17,
+        "valuesets": 10,
+        "codeSystems": 17
+      }
+    },
+    {
+      "name": "Bidirectional Services eReferrals (BSeR) FHIR IG",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.bser",
+      "description": "The Bidirectional Services eReferrals (BSeR) FHIR IG provides guidance on STU3 FHIR Resources and US Core IG profiles for use in exchanging a referral request and specific program data from a clinical provider to a typically extra-clinical program service provider, such as a diabetes prevention program, a smoking quitline, or a hypertension management training program. And provides for the return of feedback information from the service program to the referring provider",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/bser/history.html",
+      "canonical": "http://hl7.org/fhir/us/bser",
+      "ci-build": "http://build.fhir.org/ig/HL7/bser",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 40,
+        "valuesets": 2,
+        "codeSystems": 2,
+        "examples": 59
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.bser#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/bser/2023Sep"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.bser#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/bser/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Breast Radiology Report (BRR)",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.breast-radiology",
+      "description": "Breast Radiology CIMI Logical Models and FHIR Profiles",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/breast-radiology/history.html",
+      "canonical": "http://hl7.org/fhir/us/breast-radiology",
+      "ci-build": "http://build.hl7.org/fhir/us/breast-radiology",
+      "analysis": {
+        "examples": 125
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.us.breast-radiology#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/breast-radiology/2020May"
+        }
+      ]
+    },
+    {
+      "name": "Bulk Retrieval of Public Health Data",
+      "category": "Public Health",
+      "npm-name": "hl7.fhir.us.ph-bulk-data",
+      "description": "The Bulk FHIR data access IG facilitates the sharing of data on populations of individuals and is a Priority Area for the Helios FHIR Accelerator for Public Health. This approach allows users of Electronic Health Records (EHR) systems and other electronic platforms to utilize the carefully curated data managed by public health programs. By implementing FHIR Bulk data, authorized users can efficiently retrieve data for defined groups through a standardized and reusable method. This process enables public health systems to generate and transmit essential information quickly while reducing the time and effort needed to respond to data requests in proprietary and custom formats.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/ph-bulk-data/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/ph-bulk-data",
+      "ci-build": "http://build.fhir.org/ig/HL7/us-helios-bulk/en/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Informative 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.ph-bulk-data#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ph-bulk-data/2026May"
+        }
+      ]
+    },
+    {
+      "name": "Canadian Baseline",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.ca.baseline",
+      "description": "Base Canadian national implementation guide",
+      "authority": "HL7 Canada",
+      "product": [
+        "fhir"
+      ],
+      "country": "ca",
+      "history": "https://simplifier.net/canadianfhirbaselineprofilesca-core",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/ca/baseline",
+      "ci-build": "https://build.fhir.org/ig/HL7-Canada/ca-baseline",
+      "editions": [
+        {
+          "name": "Public Comment",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.ca.baseline#1.1.3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://packages.simplifier.net/hl7.fhir.ca.baseline/1.1.3"
+        },
+        {
+          "name": "Public Comment",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.ca.baseline#1.0.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://packages.simplifier.net/hl7.fhir.ca.baseline/1.0.2"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 31,
+        "extensions": 13,
+        "valuesets": 9,
+        "codeSystems": 2
+      }
+    },
+    {
+      "name": "Canonical Resource Management Infrastructure Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "hl7.fhir.uv.crmi",
+      "description": "The Canonical Resource Management Infrastructure implementation guide defines profiles, operations, capability statements and guidance to facilitate the content management lifecycle for authoring, publishing, distribution, and implementation of FHIR knowledge artifacts such as value sets, profiles, libraries, rules, and measures. The guide is intended to be used by specification and content implementation guide authors as both a dependency for validation of published artifacts, and a guide for construction and publication of content.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/crmi/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/crmi",
+      "ci-build": "http://build.fhir.org/ig/HL7/crmi-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.uv.crmi#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/crmi/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "CardX - Cardiac Implantable Electronic Devices",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.uv.cardx-cied",
+      "description": "The CardX - Cardiac Implantable Electronic Devices IG defines universal standards to enable interoperable data exchange for CIED use cases and data. The IG consists of FHIR profiles, extensions, transactions, and value sets needed to represent, query for, and exchange data for evidence-based management of CIED patients.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cardx-cied/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cardx-cied",
+      "ci-build": "http://build.fhir.org/ig/HL7/cardx-cied",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.cardx-cied#1.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/cardx-cied/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "CardX Hypertension Management IG",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.cardx-htn-mng",
+      "description": "This implementation guide is intended to increase the quality of blood pressure data observed by the patient taken in a non-clinical setting or at home.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cardx-htn-mng/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cardx-htn-mng",
+      "ci-build": "http://build.fhir.org/ig/HL7/cardx-htn-mng",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.cardx-htn-mng#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cardx-htn-mng/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CARIN Blue Button Implementation Guide",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.carin-bb",
+      "description": "Implementation guide for an API similar to the CMS Medicare Blue Button 2.0 API, FHIR R3 based, that will allow consumer-directed exchange of commercial Health Plan/Payer adjudicated claims data to meet the requirements of the CMS Interoperability and Patient Access proposed rule.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/carin-bb/history.html",
+      "canonical": "http://hl7.org/fhir/us/carin-bb",
+      "ci-build": "http://build.fhir.org/ig/HL7/carin-bb",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 10,
+        "valuesets": 48,
+        "codeSystems": 36,
+        "examples": 28
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.2.0",
+          "package": "hl7.fhir.us.carin-bb#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/carin-bb/STU2.2"
+        }
+      ]
+    },
+    {
+      "name": "CARIN Digital Insurance Card",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.insurance-card",
+      "description": "This IG provides a structured approach to take the data elements on an individual consumer\u2019s health insurance card and represent them using FHIR Resources (i.e., a 'Digital Insurance Card' Bundle). The IG also documents patterns to share Digital Insurance Cards via FHIR APIs, SMART Health Cards, and SMART Health Links. This information can be provided by the health insurance company and presented by the member as proof of insurance when interacting with healthcare providers. Eligibility checks are not in the scope of this IG",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/insurance-card/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/insurance-card",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 3,
+        "extensions": 10,
+        "valuesets": 5,
+        "codeSystems": 5,
+        "examples": 4
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/carin-digital-insurance-card",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.insurance-card#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/insurance-card/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.insurance-card#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/insurance-card/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CARIN Real-time Pharmacy Benefit Check",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.carin-rtpbc",
+      "description": "This is a guide for implementing a consumer-focused Real-time Pharmacy Benefit Check (RTPBC) process using HL7 FHIR\u00ae R4.Using RTPBC, a patient can learn the cost and insurance coverage related to medications they\u2019ve been prescribed",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/carin-rtpbc/history.html",
+      "canonical": "http://hl7.org/fhir/us/carin-rtpbc",
+      "ci-build": "http://build.fhir.org/ig/HL7/carin-rtpbc",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "messaging": true,
+        "clinicalCore": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 10,
+        "extensions": 2,
+        "valuesets": 9,
+        "codeSystems": 3,
+        "examples": 16
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.carin-rtpbc#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/carin-rtpbc/2026May"
+        }
+      ]
+    },
+    {
+      "name": "CCDA on FHIR",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.fhir.us.ccda",
+      "description": "US Realm Implementation Guide (IG) addressing the key aspects of Consolidated CDA (C-CDA) required for Meaningful Use (MU). This IG focuses on the clinical document header and narrative constraints necessary for human readability, and references the Data Access Framework (DAF) implementation guide for coded data representation",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/ccda/history.html",
+      "canonical": "http://hl7.org/fhir/us/ccda",
+      "ci-build": "http://build.fhir.org/ig/HL7/ccda-on-fhir",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "profiles": 12,
+        "extensions": 8,
+        "valuesets": 10,
+        "examples": 32
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.ccda#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ccda/2025Jan"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.2.0",
+          "package": "hl7.fhir.us.ccda#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ccda/STU1.2"
+        },
+        {
+          "name": "STU 1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.ccda#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ccda/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.ccda#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ccda/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CCDA: Consolidated CDA Release",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.cda.us.ccda",
+      "description": "C-CDA 3.0 merges the C-CDA R2.1 and the C-CDA Companion Guides, adds C-CDA enhancement requests, and incorporates new design and guidance for USCDI V4. The guide represents C-CDA templates using HL7 FHIR StructureDefinition. It is built upon the underlying CDA standard\u2019s structures defined as Logical Models. These FHIR Logical models are abstract data structures which have been instantiated into physical CDA templates to be implemented in CDA data exchange. As such, it adheres to the CDA Release 2.0 standard and remains a CDA-based Implementation Guide (IG).",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/cda/stds/ccda/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/cda/us/ccda",
+      "ci-build": "http://build.fhir.org/ig/HL7/CDA-ccda",
+      "product": [
+        "fhir",
+        "cda"
+      ],
+      "editions": [
+        {
+          "name": "CCDA 5.0 Ballot",
+          "ig-version": "5.0.0-ballot",
+          "package": "hl7.cda.us.ccda#5.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/cda/us/ccda/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "CDA: Clinical Document Architecture",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.cda.uv.core",
+      "description": "This Implementation Guide is a representation of the Clinical Document Architecture (CDA) specification using FHIR Logical Models expressed as FHIR StructureDefinition instances.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/cda/stds/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/cda/stds/core",
+      "ci-build": "http://build.fhir.org/ig/HL7/CDA-core-sd",
+      "product": [
+        "fhir",
+        "cda"
+      ],
+      "editions": [
+        {
+          "name": "CDA 2.0 Informative",
+          "ig-version": "2.0.2-sd",
+          "package": "hl7.cda.uv.core#2.0.2-sd",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/cda/stds/core/2.0.2-sd"
+        }
+      ]
+    },
+    {
+      "name": "CDC Opioid MME Calculator",
+      "category": "Quality / CDS",
+      "npm-name": "fhir.cdc.opioid-mme-r4",
+      "description": "This implementation guide provides Morphine Milligram Equivalent (MME) calculation logic as described by the Centers For Disease Control and Prevention (CDC) Guideline for Prescribing Opioids for Chronic Pain \u2014 United States, 2016",
+      "authority": "CQF",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://fhir.org/guides/cdc/opioid-mme-r4/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.org/guides/cdc/opioid-mme-r4",
+      "ci-build": "http://build.fhir.org/ig/cqframework/opioid-mme-r4",
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "3.0.0",
+          "package": "fhir.cdc.opioid-mme-r4#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.org/guides/cdc/opioid-mme-r4/3.0.0"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 1,
+        "codeSystems": 3,
+        "examples": 12
+      }
+    },
+    {
+      "name": "CDISC Lab Semantics in FHIR",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.cdisc-lab",
+      "description": "The IG shows how laboratory data in FHIR format can be converted into the CDISC LAB or LB format",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cdisc-lab/history.html",
+      "canonical": "http://hl7.org/fhir/uv/cdisc-lab",
+      "ci-build": "http://build.fhir.org/ig/HL7/cdisc-lab",
+      "analysis": {
+        "rest": true
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.cdisc-lab#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cdisc-lab/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CDISC Mapping FHIR IG",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.cdisc-mapping",
+      "description": "This implementation guide defines authoritative mappings between the CDISC LAB, SDTM and CDASH standards and the corresponding HL7 FHIR resources to ease interoperability and data conversion between systems implementing these standards.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cdisc-mapping/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cdisc-mapping",
+      "ci-build": "http://build.fhir.org/ig/HL7/cdisc-map",
+      "analysis": {},
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.cdisc-mapping#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cdisc-mapping/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CDS Hooks Hook Library",
+      "category": "Clinical Decision Support",
+      "npm-name": "hl7.fhir.uv.cds-hooks-library",
+      "description": "CDS Hooks Hook Library",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://cds-hooks.hl7.org/hooks/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://cds-hooks.hl7.org/hooks",
+      "ci-build": "http://build.fhir.org/ig/HL7/cds-hooks-library",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.uv.cds-hooks-library#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://cds-hooks.hl7.org/hooks/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CDS Hooks Specification",
+      "category": "Clinical Decision Support",
+      "npm-name": "hl7.fhir.uv.cds-hooks",
+      "description": "CDA-Hooks Specification",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://cds-hooks.hl7.org/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://cds-hooks.hl7.org",
+      "ci-build": "http://build.fhir.org/ig/HL7/cds-hooks",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "R3 Ballot",
+          "ig-version": "3.0.0-ballot",
+          "package": "hl7.fhir.uv.cds-hooks#3.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://cds-hooks.hl7.org/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "CH ATC (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-atc",
+      "description": "The profile CH ATC defines the audit trail consumption requirements for the EPR in Switzerland which a community has to provide for a patients audit trail.",
+      "authority": "FOPH",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-atc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-atc",
+      "ci-build": "http://build.fhir.org/ig/ehealthsuisse/ch-atc",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Draft Draft",
+          "ig-version": "3.3.0",
+          "package": "ch.fhir.ig.ch-atc#3.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-atc/3.3.0"
+        }
+      ]
+    },
+    {
+      "name": "CH EPR FHIR (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-epr-fhir",
+      "description": "This national extension provides a FHIR based API for the Swiss EPR by extending the IHE FHIR based mobile profiles.",
+      "authority": "FOPH",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-epr-fhir/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-epr-fhir",
+      "ci-build": "http://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "DSTU 4",
+          "ig-version": "4.0.1",
+          "package": "ch.fhir.ig.ch-epr-fhir#4.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-epr-fhir/4.0.1"
+        }
+      ]
+    },
+    {
+      "name": "CH eTOC (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-etoc",
+      "description": "Transition of Care Implementation Guide based on the IPAG report.",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-etoc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-etoc",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-etoc",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 3",
+          "ig-version": "3.0.0",
+          "package": "ch.fhir.ig.ch-etoc#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-etoc/3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "CH IPS (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-ips",
+      "description": "Swiss IPS based on the International Patient Summary Implementation Guide.",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-ips/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-ips",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-ips/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "ch.fhir.ig.ch-ips#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-ips/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "CH LAB-Order (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-lab-order",
+      "description": "Swiss Implementation Guide for the exchange of order data in the laboratory sector.",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-lab-order/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-lab-order",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-lab-order",
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "ch.fhir.ig.ch-lab-order#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-lab-order/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "CH LAB-Report (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-lab-report",
+      "description": "Implementation Guide for Laboratory Reports in Switzerland.",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-lab-report/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-lab-report",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-lab-report",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "ch.fhir.ig.ch-lab-report#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-lab-report/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "CH RAD-Order (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-rad-order",
+      "description": "Based on the CH ORF Implementation Guide for Order & Referral in the Radiology domain to achieve a syntactical and semantically consistent cross enterprise information exchange.",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-rad-order/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-rad-order",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-rad-order",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "ch.fhir.ig.ch-rad-order#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-rad-order/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "CH Term (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-term",
+      "description": "FHIR implementation guide containing terminology that is used in Switzerland for the core profiles, various exchange formats and also in the context of the Swiss electronic patient record (EPR).",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-term/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-term",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-term",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU",
+          "ig-version": "3.1.0",
+          "package": "ch.fhir.ig.ch-term#3.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-term/3.1.0"
+        }
+      ]
+    },
+    {
+      "name": "CH VACD (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-vacd",
+      "description": "The CH VACD implementation guide describes the FHIR representation of the defined documents for the exchange of immuniuzation",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-vacd/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-vacd",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-vacd",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 5",
+          "ig-version": "5.0.0",
+          "package": "ch.fhir.ig.ch-vacd#5.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-vacd/5.0.0"
+        }
+      ]
+    },
+    {
+      "name": "CH-AllergyIntolerance (R4)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-allergyintolerance",
+      "description": "Swiss Implementation Guide for Allergy & Intolerance based on the recommendations of the interprofessional working group EPR (IPAG).",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-allergyintolerance/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-allergyintolerance",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-allergyintolerance",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 3",
+          "ig-version": "3.0.0",
+          "package": "ch.fhir.ig.ch-allergyintolerance#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-allergyintolerance/3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Clinical Information Sharing Implementation Guide",
+      "category": "Clinical Documents",
+      "npm-name": "jp-eCSCLINS.r4",
+      "description": "This guide defines the FHIR data representation and associated profiles for the two documents and the five pieces of information defined by the Ministry of Health, Labor and Welfare",
+      "authority": "HL7 Japan (JAMI)",
+      "product": [
+        "fhir"
+      ],
+      "country": "jp",
+      "language": [
+        "ja"
+      ],
+      "history": "https://jpfhir.jp/fhir/clins/history.html",
+      "canonical": "http://jpfhir.jp/fhir/clins",
+      "editions": [
+        {
+          "name": "jp-eCSCLINS.r4",
+          "ig-version": "1.11.0",
+          "package": "clinical-information-sharing#1.11.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://jpfhir.jp/fhir/clins/igv1"
+        }
+      ]
+    },
+    {
+      "name": "Clinical Order Workflows",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.uv.cow",
+      "description": "Clinical Order Workflows",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cow/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cow",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-cow-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.cow#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cow/2025May"
+        }
+      ]
+    },
+    {
+      "name": "Clinical Quality Framework Common FHIR Assets",
+      "category": "Quality / CDS",
+      "npm-name": "fhir.cqf.common",
+      "description": "This implementation guide contains common FHIR assets for use in CQFramework content IGs, including FHIRHelpers and the FHIR-ModelInfo libraries",
+      "authority": "CQF",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://fhir.org/guides/cqf/common/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.org/guides/cqf/common",
+      "ci-build": "http://build.fhir.org/ig/cqframework/cqf",
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "4.0.1",
+          "package": "fhir.cqf.common#4.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.org/guides/cqf/common/4.0.1"
+        }
+      ],
+      "analysis": {
+        "valuesets": 2
+      }
+    },
+    {
+      "name": "Clinical Quality Language Specification",
+      "category": "Infrastructure",
+      "npm-name": "hl7.cql",
+      "description": "Clinical Quality Language (CQL) is a high-level, domain-specific language focused on clinical quality and targeted at measure and decision support artifact authors. In addition, this specification describes a machine-readable canonical representation called Expression Logical Model (ELM) targeted at implementations and designed to enable sharing of clinical knowledge.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://cql.hl7.org/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://cql.hl7.org",
+      "ci-build": "http://build.fhir.org/ig/HL7/cql",
+      "analysis": {
+        "error": "Error reading http://cql.hl7.org/N1/package.tgz: null"
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "R2 STU 1",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.cql#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://cql.hl7.org/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "Clinical Study Schedule of Activities",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.vulcan-schedule",
+      "description": "This guide provides best practice guidance for representing the schedule of activities (visits/encounters) in a Research Study and for relating EHR data to that schedule.  It also includes definition of blocks of standard activities that can subsequently be used as components of studies.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/vulcan-schedule/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/vulcan-schedule",
+      "ci-build": "http://build.fhir.org/ig/HL7/Vulcan-schedule-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.vulcan-schedule#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/vulcan-schedule/STU1"
+        }
+      ]
+    },
+    {
+      "name": "CodeX\u2122 Radiation Therapy",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.codex-radiation-therapy",
+      "description": "The CodeX Radiation Therapy (RT) Implementation Guide (IG) describes how to represent and exchange radiation therapy treatment information. The CodeX RT IG enables radiation oncology information systems to generate treatment summaries that are retrievable by health systems, or other information systems, for display within the EHR interface to be used for care coordination and data reuse. ",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/codex-radiation-therapy/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/codex-radiation-therapy",
+      "ci-build": "http://build.fhir.org/ig/codex-radiation-therapy",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.codex-radiation-therapy#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/codex-radiation-therapy/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.codex-radiation-therapy#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/codex-radiation-therapy/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Common CQL Assets for FHIR (US-Based)",
+      "category": "Quality/CDS",
+      "npm-name": "hl7.fhir.us.cql",
+      "description": "Common CQL Assets for FHIR",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/cql/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/cql",
+      "ci-build": "http://build.fhir.org/ig/HL7/us-cql-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Informative 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.cql#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cql/2026May"
+        }
+      ]
+    },
+    {
+      "name": "Common Data Models Harmonization FHIR IG",
+      "category": "Research",
+      "npm-name": "hl7.fhir.us.cdmh",
+      "description": "The CDMH FHIR IG provides the guidance necessary to map the four common data models namely Sentinel, PCORnet CDM, i2b2 and OMOP to FHIR resources and profiles",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/cdmh/history.html",
+      "canonical": "http://hl7.org/fhir/us/cdmh",
+      "ci-build": "http://build.fhir.org/ig/HL7/cdmh",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "trials": true,
+        "profiles": 15,
+        "extensions": 22,
+        "valuesets": 25,
+        "codeSystems": 38,
+        "examples": 15
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.cdmh#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cdmh/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Common FHIR profile vendor collaboration",
+      "category": "EHR Access",
+      "npm-name": "care.commonprofiles.fhir",
+      "description": "ImplementationGuide published by a collaborative group of Swedish stakeholders of healthcare IT systems.",
+      "authority": "CommonProfiles.care (SE)",
+      "country": "se",
+      "history": "https://commonprofiles.care/fhir/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://commonprofiles.care/fhir",
+      "ci-build": "https://build.fhir.org/ig/commonprofiles-care/fhir",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.1",
+          "package": "care.commonprofiles.fhir#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://commonprofiles.care/fhir/1.0.1"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Computable Care Guidelines (CCG)",
+      "category": "Computable Care Guidelines",
+      "npm-name": "ihe.qrph.ccg",
+      "description": "The IHE Computable Care Guidelines (CCG) Profile specifies a normative grammar and a normative transaction processing model that allows evidence-based care recommendations to be expressed in a way that a digital health solution can ingest and operationalize. This is an implementable and conformance-testable specification. It is targeted to regulated healthcare markets where the support for multiple conditions is an important requirement. The CCG Profile supports jurisdictions that want to leverage digital health to systemically improve the adoption of guideline-adherent best practices across an entire care delivery network.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/QRPH/CCG/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/QRPH/CCG",
+      "ci-build": "http://build.fhir.org/ig/IHE/QRPH.CCG",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.qrph.ccg#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/QRPH/CCG/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Continuous Glucose Monitoring",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.cgm",
+      "description": "Continuous Glucose Monitoring",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cgm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cgm",
+      "ci-build": "http://build.fhir.org/ig/HL7/cgm",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.cgm#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cgm/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Coverage Requirements Determination (Da Vinci)",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-crd",
+      "description": "Provides a mechanism for healthcare providers to discover guidelines, pre-authorization requirements and other expectations from payor organizations related to a proposed medication, procedure or other service associated with a patient's insurance coverage. Supports both patient-specific and patient-independent information retrieval",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/davinci-crd/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-crd",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-crd",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "scheduling": true,
+        "profiles": 18,
+        "extensions": 1,
+        "valuesets": 8,
+        "codeSystems": 3,
+        "examples": 19
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2.2",
+          "ig-version": "2.2.1",
+          "package": "hl7.fhir.us.davinci-crd#2.2.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-crd/2.2.1"
+        }
+      ]
+    },
+    {
+      "name": "Csiro Stars",
+      "category": "Diagnostics",
+      "npm-name": "csiro.stars",
+      "description": "The STARS network provides restricted sample submission. This implementation guide outlines the requirements for users to implement a common standard FHIR protocol to transfer specimen information between laboratories for the purpose of testing.",
+      "authority": "CSIRO",
+      "country": "au",
+      "history": "https://starsapi.csiro.au/fhir-ig/stars/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://starsapi.csiro.au/fhir-ig/stars",
+      "ci-build": "https://starsapi.csiro.au/fhir-ig/stars",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.5.1",
+          "package": "csiro.stars#0.5.1",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://starsapi.csiro.au/fhir-ig/stars/0.5.1"
+        }
+      ]
+    },
+    {
+      "name": "Czech National FHIR R4 Core and Base Implementation Guide STU 1",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.cz.core",
+      "description": "This implementation guide specifies Base and core profiles used by Czech Republic national interoperability project.",
+      "authority": "HL7 Czech Republic",
+      "country": "cz",
+      "history": "https://hl7.cz/fhir/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.cz/fhir/core",
+      "ci-build": "http://build.fhir.org/ig/HL7-cz/cz-core",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "0.3.0",
+          "package": "hl7.fhir.cz.core#0.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.cz/fhir/core/0.3.0"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci CDex",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-cdex",
+      "description": "Provider-to-payer and payer-related provider-to-provider data exchange to improve care coordination, support risk adjustment, ease quality management, facilitate claims auditing and confirm medical necessity, improve member experience, and support orders and referrals.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-cdex/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-cdex",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-ecdx",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "carePlanning": true,
+        "profiles": 1,
+        "operations": 1,
+        "valuesets": 3,
+        "codeSystems": 1,
+        "examples": 19
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.davinci-cdex#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-cdex/STU2.1"
+        },
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.davinci-cdex#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-cdex/STU2"
+        },
+        {
+          "name": "STU1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.davinci-cdex#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-cdex/STU1.1"
+        },
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-cdex#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-cdex/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Health Record Exchange",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-hrex",
+      "description": "A library of shared artifacts used by other Da Vinci and payer related implementation guides",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/davinci-hrex/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-hrex",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-ehrx",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "profiles": 11,
+        "extensions": 4,
+        "operations": 1,
+        "valuesets": 2,
+        "codeSystems": 1,
+        "examples": 22
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.davinci-hrex#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-hrex/STU1.1"
+        },
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-hrex#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-hrex/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Patient Cost Transparency Implementation Guide",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-pct",
+      "description": "Enables standard exchange of healthcare cost for items, services, and collection of services among stakeholders such as payers, providers, and patients in support of driving transparency for patients with accurate, timely access to cost of medical care prior to delivery of care in order to become better stewards of their healthcare dollars.   This guide creates a standard exchange to reduce administrative burden for communicating Good Faith Estimates (GFE) from providers of costs and services to payers and then, payers creating and returning an Advanced Explanation of Benefits (AEOB) back to the patient as required by law.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-pct/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/davinci-pct",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 11,
+        "extensions": 17,
+        "operations": 1,
+        "valuesets": 18,
+        "codeSystems": 14,
+        "examples": 18
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-pct",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.1",
+          "package": "hl7.fhir.us.davinci-pct#2.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pct/STU2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Payer Coverage Decision Exchange (PCDE) FHIR IG",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-pcde",
+      "description": "Payer coverage decision exchange will promote continuity of treatment when a member moves from one covered payer to another without increasing provider burden or cost to the member. This IG enables member-authorized sharing of treatment, conditions, authorizations, relevant guidelines and supporting documentation from an original payer to a new payer when a patient changes coverage plans.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-pcde/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-pcde",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-pcde",
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 5,
+        "valuesets": 3,
+        "codeSystems": 1,
+        "examples": 5
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-pcde#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pcde/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci PDex",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-pdex",
+      "description": "Payer data exchange with providers to support care coordination. Member-authorized sharing to Third-Party applications of Health Plan's Healthcare Service Network, Pharmacy Network and Prescription Drug Formulary",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-pdex/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-pdex",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-epdx",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 5,
+        "extensions": 6,
+        "operations": 1,
+        "valuesets": 12,
+        "codeSystems": 13,
+        "examples": 36
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2.1",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.davinci-pdex#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pdex/STU2.1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Prior Authorization Support (PAS) FHIR IG",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-pas",
+      "description": "This IG allows providers the ability to easily identify the need for payer authorizations, assemble necessary information, identify and supply missing information and submit it to the payer electronically and receive a response in real time within the clinical workflow.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-pas/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-pas",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-pas",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 23,
+        "extensions": 37,
+        "operations": 2,
+        "valuesets": 12,
+        "codeSystems": 6,
+        "examples": 29
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.2.1",
+          "package": "hl7.fhir.us.davinci-pas#2.2.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pas/2.2.1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Risk Adjustment FHIR Implementation Guide",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-ra",
+      "description": "Enable standard exchange of risk-based coding gaps among stakeholders such as payers, providers, and government care programs in support of driving towards accurate and complete documentation of health conditions that would lead to more accurate risk-adjustment payment calculations, reduced administrative burden, and improved quality of care.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-ra/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/davinci-ra",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-ra",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "measures": true,
+        "profiles": 4,
+        "extensions": 6,
+        "operations": 1,
+        "valuesets": 3,
+        "codeSystems": 3,
+        "examples": 72
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.davinci-ra#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-ra/STU2.1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Unsolicited Notifications (Alerts)",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-alerts",
+      "description": "The goal of this IG is to support the real-time exchange of alerts and notifications that impact patient care and value based or risk based services",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-alerts/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-alerts",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-alerts",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 8,
+        "valuesets": 4,
+        "codeSystems": 1,
+        "examples": 11
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.davinci-alerts#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-alerts/STU1.1"
+        },
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-alerts#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-alerts/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Da Vinci Value-Based Performance Reporting Implementation Guide",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-vbpr",
+      "description": "This implementation guide enables value-based performance reports to be specified in a standard format and exchanged using standardized mechanisms between payers and providers to support the shift from fee-for-service to value-based care.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-vbpr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/davinci-vbpr",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-vbpr",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.davinci-vbpr#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-vbpr/STU1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "DAF",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.us.daf",
+      "description": "Basic arrangements for accessing meaningful use data from EHR systems **NOTE: DAF has been superseded by Argonaut, DAF-Research and US-Core**",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/daf/history.html",
+      "canonical": "http://hl7.org/fhir/us/daf",
+      "ci-build": "http://build.fhir.org/ig/HL7/daf-research",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 5,
+        "extensions": 2,
+        "operations": 3,
+        "valuesets": 2,
+        "codeSystems": 2
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.daf#2.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/daf-research/STU2"
+        },
+        {
+          "name": "DSTU 1",
+          "ig-version": "1.0.2",
+          "package": "hl7.fhir.us.daf#1.0.2",
+          "fhir-version": [
+            "1.0.2"
+          ],
+          "url": "http://hl7.org/fhir/DSTU2/daf/daf.html"
+        }
+      ]
+    },
+    {
+      "name": "DAF-Research",
+      "category": "Research",
+      "npm-name": "hl7.fhir.us.daf-research",
+      "description": "DAF-Research IG focuses on enabling researchers to access data from multiple organizations",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/daf/history.html",
+      "canonical": "http://hl7.org/fhir/us/daf",
+      "ci-build": "http://build.fhir.org/ig/HL7/daf-research",
+      "editions": [
+        {
+          "name": "STU",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.daf-research#2.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/daf-research"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id hl7.fhir.us.daf-research#2.0.0"
+      }
+    },
+    {
+      "name": "Danish Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.dk.core",
+      "description": "Base danish national implementation guide",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.dk/fhir/core/history.html",
+      "canonical": "http://hl7.dk/fhir/core",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 10,
+        "extensions": 2,
+        "valuesets": 6,
+        "codeSystems": 15,
+        "examples": 12
+      },
+      "ci-build": "http://build.fhir.org/ig/hl7dk/dk-core",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "3.6.0",
+          "package": "hl7.fhir.dk.core#3.6.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.dk/fhir/core/3.6.0"
+        }
+      ]
+    },
+    {
+      "name": "Data Exchange for Quality Measures (Da Vinci)",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-deqm",
+      "description": "Provides a mechanism for healthcare providers and data aggregators to exchange quality measure information using subscription, query, and push methods",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/davinci-deqm/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-deqm",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-deqm",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "financials": true,
+        "medsMgmt": true,
+        "measures": true,
+        "profiles": 11,
+        "extensions": 8,
+        "operations": 1,
+        "valuesets": 2,
+        "codeSystems": 2,
+        "examples": 87
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU5 (v5.0.0)",
+          "ig-version": "5.0.0",
+          "package": "hl7.fhir.us.davinci-deqm#5.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/STU5"
+        },
+        {
+          "name": "STU4 (v4.0.0)",
+          "ig-version": "4.0.0",
+          "package": "hl7.fhir.us.davinci-deqm#4.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/STU4"
+        },
+        {
+          "name": "STU 3",
+          "ig-version": "3.1.0",
+          "package": "hl7.fhir.us.davinci-deqm#3.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/STU3.1"
+        },
+        {
+          "name": "STU 3",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.us.davinci-deqm#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/STU3"
+        },
+        {
+          "name": "STU 3",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.davinci-deqm#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/2020Sep"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.davinci-deqm#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-deqm#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-deqm/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Data Exchange Profiles for 2022 CDC Clinical Practice Guideline for Prescribing Opioids",
+      "category": "Quality/CDS",
+      "npm-name": "hl7.fhir.us.cdc-opioid-cpg",
+      "description": "Defines exchange expectations for systems that implement the CDC's Clinical Practice Guideline for Prescribing Opioids, both in terms of the data required to evaluate whether recommendations are applicable, as well as the data required to represent proposals resulting from those recommendations.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/cdc-opioid-cpg/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/cdc-opioid-cpg",
+      "ci-build": "http://build.fhir.org/ig/HL7/cdc-opioid-cpg",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.cdc-opioid-cpg#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cdc-opioid-cpg/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "Davinci pdex Plan Net",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.us.davinci-pdex-plan-net",
+      "description": "A subset of the functionality described in the Validated healthcare directory IG",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-pdex-plan-net/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-pdex-plan-net",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-pdex-plan-net",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 9,
+        "extensions": 12,
+        "valuesets": 24,
+        "codeSystems": 14,
+        "examples": 49
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.2.0",
+          "package": "hl7.fhir.us.davinci-pdex-plan-net#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1.2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.davinci-pdex-plan-net#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-pdex-plan-net#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1"
+        }
+      ]
+    },
+    {
+      "name": "DaVinci Postable Remittance FHIR Implementation Guide",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-pr",
+      "description": "This IG provides a FHIR API to search for and retrieve a copy of a previously issued postable remittance.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-pr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/davinci-pr",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-pr",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-pr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-pr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Dental Data Exchange",
+      "category": "Clinical Observations",
+      "npm-name": "hl7.fhir.us.dental-data-exchange",
+      "description": "This FHIR R4 IG defines exchange of medical and dental information exchange between medical/dental and dental/dental realms, including referral and corresponding consult note using US-core, CCDAonFHIR, Occupational Data for Health, and Da Vinci profiles.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/dental-data-exchange/history.html",
+      "canonical": "http://hl7.org/fhir/us/dental-data-exchange",
+      "ci-build": "http://build.fhir.org/ig/HL7/dental-data-exchange",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 7,
+        "valuesets": 5,
+        "codeSystems": 1,
+        "examples": 64
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.dental-data-exchange#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/dental-data-exchange/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Dermatology Image Annotation IG",
+      "category": "Diagnostics",
+      "npm-name": "annotatemd.dermatology-annotation",
+      "description": "FHIR R4 profiles for structured dermatology image annotation with AI transparency",
+      "authority": "Annotate MD",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://annotatemd.com/fhir/ig",
+      "ci-build": "https://build.fhir.org/ig/s25rawlins/annotate-md",
+      "editions": [
+        {
+          "name": "0.1.0 (Draft)",
+          "ig-version": "0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://annotatemd.com/fhir/ig"
+        }
+      ]
+    },
+    {
+      "name": "DICOM\u00ae SR to FHIR Resource Mapping IG",
+      "category": "Imaging",
+      "npm-name": "hl7.fhir.uv.dicom-sr",
+      "description": "Provides guidance for extracting key content from DICOM Structured Report (SR) objects into FHIR Observations  to make use of the results with  the larger hospital enterprise.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/dicom-sr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/dicom-sr",
+      "ci-build": "http://build.fhir.org/ig/HL7/dicom-sr",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.dicom-sr#1.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/dicom-sr/2024Sep"
+        }
+      ]
+    },
+    {
+      "name": "DK MedCom Acknowledgement",
+      "category": "Frameworks",
+      "npm-name": "medcom.fhir.dk.acknowledgement",
+      "description": "This IG includes profiles used in MedCom's Acknowledgement standard. An Acknowledgement is used as a receipt in messagebased communication.",
+      "authority": "MedCom (DK)",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/acknowledgement/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/acknowledgement",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-acknowledgement",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "2.0.1",
+          "package": "medcom.fhir.dk.acknowledgement#2.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/acknowledgement/2.0.1"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.0.0",
+          "package": "medcom.fhir.dk.acknowledgement#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/acknowledgement/2.0.0"
+        },
+        {
+          "name": "STU",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.acknowledgement#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/fhir/ig/dk-medcom-acknowledgement"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "DK MedCom CareCommunication",
+      "category": "Care Management",
+      "npm-name": "medcom.fhir.dk.carecommunication",
+      "description": "This IG includes profiles used in MedCom's CareCommunication standard. The purpose of CareCommunication is to support messagebased, digital communication between parties within Danish healthcare and the social area.",
+      "authority": "MedCom (DK)",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/carecommunication/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/carecommunication",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-carecommunication",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "3.0.0",
+          "package": "medcom.fhir.dk.carecommunication#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/carecommunication/3.0.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.0.0",
+          "package": "medcom.fhir.dk.carecommunication#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/carecommunication/2.0.0"
+        },
+        {
+          "name": "STU",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.carecommunication#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/fhir/ig/dk-medcom-carecommunication"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "DK MedCom Core",
+      "category": "Frameworks",
+      "npm-name": "medcom.fhir.dk.core",
+      "description": "This IG includes core profiles defined by MedCom. These profiles are used in MedCom's FHIR standards.",
+      "authority": "MedCom (DK)",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/core",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-core",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "2.3.0",
+          "package": "medcom.fhir.dk.core#2.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/core/2.3.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.2.0",
+          "package": "medcom.fhir.dk.core#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/core/2.2.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.1.0",
+          "package": "medcom.fhir.dk.core#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/core/2.1.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.0.0",
+          "package": "medcom.fhir.dk.core#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/core/2.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "DK MedCom HomeCareObservation",
+      "category": "Care Management",
+      "npm-name": "medcom.fhir.dk.homecareobservation",
+      "description": "This Implementation Guide contains profiles developed to be part of a production trial of the communication between the general practitioner and municipal acute care team.      ",
+      "authority": "MedCom",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/homecareobservation/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/homecareobservation",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-homecareobservation",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.homecareobservation#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/homecareobservation/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "DK MedCom HospitalNotification",
+      "category": "Care Management",
+      "npm-name": "medcom.fhir.dk.hospitalnotification",
+      "description": "This IG includes profiles used in MedCom's HospitalNotification standard. The purpose of HospitalNotification is to inform the citizen\u2019s current care and health provider in the primary sector about the start, end, and period of leave of the citizen\u2019s stay at the hospital. The communication is messagebased.",
+      "authority": "MedCom (DK)",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/hospitalnotification/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/hospitalnotification",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-hospitalnotification",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "3.0.1",
+          "package": "medcom.fhir.dk.hospitalnotification#3.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/hospitalnotification/3.0.1"
+        },
+        {
+          "name": "Release",
+          "ig-version": "3.0.0",
+          "package": "medcom.fhir.dk.hospitalnotification#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/hospitalnotification/3.0.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.0.0",
+          "package": "medcom.fhir.dk.hospitalnotification#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/hospitalnotification/2.0.0"
+        },
+        {
+          "name": "STU",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.hospitalnotification#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/fhir/ig/dk-medcom-hospitalnotification"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "DK MedCom Messaging",
+      "category": "Frameworks",
+      "npm-name": "medcom.fhir.dk.messaging",
+      "description": "This IG includes messaging profiles defined by MedCom. These profiles are used in messagebased communication.",
+      "authority": "MedCom (DK)",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/messaging/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/messaging",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-messaging",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "2.1.0",
+          "package": "medcom.fhir.dk.messaging#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/messaging/2.1.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "2.0.0",
+          "package": "medcom.fhir.dk.messaging#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/messaging/2.0.0"
+        },
+        {
+          "name": "STU",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.messaging#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/fhir/ig/dk-medcom-messaging"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "DK MedCom Terminology",
+      "category": "Terminology",
+      "npm-name": "medcom.fhir.dk.terminology",
+      "description": "This IG includes CodeSystems, ValueSets and ConceptMaps defined by MedCom and used in MedCom's FHIR standards.",
+      "authority": "MedCom (DK)",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/terminology/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/terminology",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-terminology",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.6.0",
+          "package": "medcom.fhir.dk.terminology#1.6.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.6.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.5.0",
+          "package": "medcom.fhir.dk.terminology#1.5.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.5.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.4.0",
+          "package": "medcom.fhir.dk.terminology#1.4.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.4.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.3.0",
+          "package": "medcom.fhir.dk.terminology#1.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.3.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.2.0",
+          "package": "medcom.fhir.dk.terminology#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.2.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.1.1",
+          "package": "medcom.fhir.dk.terminology#1.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.1.1"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.1.0",
+          "package": "medcom.fhir.dk.terminology#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.1.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.terminology#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/terminology/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Dk Terminology for XDS Metadata",
+      "category": "Clinical Documents",
+      "npm-name": "medcom.fhir.dk.xdsmetadata",
+      "description": "MedCom Terminology for XDS Metadata",
+      "authority": "MedCom",
+      "country": "dk",
+      "history": "http://medcomfhir.dk/ig/xdsmetadata/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://medcomfhir.dk/ig/xdsmetadata",
+      "ci-build": "http://build.fhir.org/ig/medcomdk/dk-medcom-xds-metadata",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.0.1",
+          "package": "medcom.fhir.dk.xdsmetadata#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/xdsmetadata/1.0.1"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.0.0",
+          "package": "medcom.fhir.dk.xdsmetadata#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://medcomfhir.dk/ig/xdsmetadata/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Document Subscription for Mobile (DSUBm)",
+      "category": "Clinical Documents",
+      "npm-name": "ihe.iti.dsubm",
+      "description": "The Document Subscription for Mobile (DSUBm) profile provides a FHIR based subscription and notification mechanisms for Document Sharing. Enabling a subscription and notification when a document publication event matches the criteria expressed in the subscription.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/DSUBm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/DSUBm",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.DSUBm/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.iti.dsubm#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/DSUBm/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Documentation des guides d'impl\u00e9mentation de l'ANS",
+      "category": "Documentation",
+      "npm-name": "ans.fr.documentation",
+      "description": "Documentation des guides d'impl\u00e9mentation de l'ANS",
+      "authority": "ANS (FR)",
+      "country": "fr",
+      "history": "https://interop.esante.gouv.fr/ig/documentation/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://interop.esante.gouv.fr/ig/documentation",
+      "ci-build": "https://ansforge.github.io/IG-documentation/ig/main",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "release",
+          "ig-version": "0.1.10",
+          "package": "ans.fr.documentation#0.1.10",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://interop.esante.gouv.fr/ig/documentation/0.1.10"
+        }
+      ]
+    },
+    {
+      "name": "Documentation Templates and Rules",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-dtr",
+      "description": "Provides a mechanism for delivering and executing payer rules related to documentation requirements for a proposed medication, procedure or other service associated with a patient's insurance coverage",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/davinci-dtr/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-dtr",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-dtr",
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "financials": true,
+        "questionnaire": true,
+        "profiles": 6,
+        "extensions": 2,
+        "operations": 1,
+        "examples": 12
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2.2",
+          "ig-version": "2.2.0",
+          "package": "hl7.fhir.us.davinci-dtr#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-dtr/2.2.0"
+        }
+      ]
+    },
+    {
+      "name": "EHDS Logical Information Models",
+      "category": "EHDS",
+      "npm-name": "xtehr.eu.ehds.models",
+      "description": "This is the second preview version of the EHDS Logical Information Models proposed by the Xt-EHR Joint Action.",
+      "authority": "Xt-EHR Joint Action",
+      "country": "eu",
+      "history": "http://www.xt-ehr.eu/fhir/models/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://www.xt-ehr.eu/fhir/models",
+      "ci-build": "http://build.fhir.org/ig/Xt-EHR/xt-ehr-common",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Edition 1 Preview",
+          "ig-version": "0.3.0",
+          "package": "xtehr.eu.ehds.models#0.3.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://www.xt-ehr.eu/fhir/models/0.3.0"
+        }
+      ]
+    },
+    {
+      "name": "eHealth FHIR Infrastructure and Security Profiles for Belgium",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.infsec",
+      "description": "eHealth FHIR Infrastructure and Security Profiles for Belgium",
+      "authority": "eHealth Platform Belgium",
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/infsec/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/infsec",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/infsec",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.infsec#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/infsec/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "eHealth FHIR Patient Care Profiles for Belgium",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.patient-care",
+      "description": "HL7 Belgium FHIR Implementation Guide - Prescription Search Support profiles",
+      "authority": "eHealth Platform",
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/patient-care/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/patient-care",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/patient-care",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.patient-care#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/patient-care/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "eHealth FHIR Patient Will Profiles for Belgium",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.patientwill",
+      "description": "eHealth FHIR Patient Will Profiles for Belgium",
+      "authority": "eHealth Platform (BE)",
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/patientwill/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/patientwill",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/patientwill",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.patientwill#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/patientwill/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "EHRS Functional Model - Record Lifecycle Events Implementation Guide",
+      "category": "Mappings to Other Standards",
+      "npm-name": "hl7.fhir.uv.ehrs-rle",
+      "description": "This implementation guide describes the expected capabilities for an Electronic Health Record System (EHR-S) that intends to adhere to the ISO/HL7 10781 Electronic Health Record System Functional Model Release 2 which covers the logging of record lifecycle events.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ehrs-rle/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ehrs-rle",
+      "ci-build": "http://build.fhir.org/ig/HL7/ehrs-rle-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Informative Release 1 Informative",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.uv.ehrs-rle#1.1.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/ehrs-rle/Informative1"
+        }
+      ]
+    },
+    {
+      "name": "Electronic Case Reporting",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.ecr",
+      "description": "The Electronic Case Reporting (eCR) Implementation Guide supports Reporting, investigation, and management via electronic transmission of clinical data from Electronic Health Records to Public Health Agencies, along with the management and processing of population cases. Ths IG covers Bi-directional information exchange and triggering and decision support",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/ecr/history.html",
+      "canonical": "http://hl7.org/fhir/us/ecr",
+      "ci-build": "http://build.fhir.org/ig/HL7/case-reporting",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 57,
+        "extensions": 25,
+        "operations": 1,
+        "valuesets": 8,
+        "codeSystems": 8,
+        "examples": 94
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 3 Ballot",
+          "ig-version": "3.0.0-ballot",
+          "package": "hl7.fhir.us.ecr#3.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ecr/2.1.2"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.ecr#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ecr/2.1.0"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.ecr#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ecr/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.ecr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ecr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "electronic Long-Term Services and Supports Implementation Guide",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.eltss",
+      "description": "Provides guidance to US Realm implementers to use the FHIR for implementing access and exchange Electronic Long-Term Services & Supports (eLTSS) Dataset data elements",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/eLTSS/history.html",
+      "ci-build": "http://build.fhir.org/ig/HL7/eLTSS",
+      "canonical": "http://hl7.org/fhir/us/eltss",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "questionnaire": true,
+        "profiles": 13,
+        "extensions": 3,
+        "logicals": 3,
+        "valuesets": 2,
+        "codeSystems": 2,
+        "examples": 5
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.eltss#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/eltss/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.eltss#1.0.0",
+          "fhir-version": [
+            "4.0.0"
+          ],
+          "url": "http://hl7.org/fhir/us/eltss/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Electronic Medicinal Product Information (ePI) FHIR Implementation Guide",
+      "category": "Pharmaceutical Mgmt",
+      "npm-name": "hl7.fhir.uv.emedicinal-product-info",
+      "description": "This guide provides best practice guidance for creating and representing electronic product information for medicinal products.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/emedicinal-product-info/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/emedicinal-product-info",
+      "ci-build": "http://build.fhir.org/ig/HL7/emedicinal-product-info",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.emedicinal-product-info#1.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/emedicinal-product-info/STU1"
+        }
+      ]
+    },
+    {
+      "name": "EMPD",
+      "category": "Medication",
+      "npm-name": "tw.gov.mohw.nhi.empd",
+      "description": "Taiwan Electronic Medication Prescription and Dispense Implementation Guide",
+      "authority": "NHIA (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://nhicore.nhi.gov.tw/empd/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://nhicore.nhi.gov.tw/empd",
+      "editions": [
+        {
+          "name": "STU0.1.0",
+          "ig-version": "0.1.0",
+          "package": "tw.gov.mohw.nhi.empd#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://nhicore.nhi.gov.tw/empd/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "EMR",
+      "category": "Clinical Observations",
+      "npm-name": "tw.gov.mohw.emr",
+      "description": "Taiwan EMR Implementation Guide",
+      "authority": "MOHW (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://twcore.mohw.gov.tw/ig/emr/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://twcore.mohw.gov.tw/ig/emr",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "0.2.0",
+          "package": "tw.gov.mohw.emr#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://twcore.mohw.gov.tw/ig/emr/0.2.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "0.1.0",
+          "package": "tw.gov.mohw.emr#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://twcore.mohw.gov.tw/ig/emr/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "EU Health Data API",
+      "category": "EHDS",
+      "npm-name": "hl7.fhir.eu.health-data-api",
+      "description": "This Implementation Guide defines HL7 FHIR-based APIs for accessing and exchanging health data in the European Health Data Space (EHDS).",
+      "authority": "Euridice (HL7 Europe,IHE Europe)",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/health-data-api/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/health-data-api",
+      "ci-build": "http://build.fhir.org/ig/euridice-org/eu-health-data-api",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.eu.health-data-api#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/health-data-api/1.0.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "Evidence Based Medicine on FHIR Implementation Guide",
+      "category": "Evidence Base Medicine",
+      "npm-name": "hl7.fhir.uv.ebm",
+      "description": "This implementation guide covers the broad scope of representation of scientific knowledge, including (1) citations to represent identification, location, classification, and attribution for knowledge artifacts; (2) components of research study design including study eligibility criteria (cohort definitions) and endpoint analysis plans; (3) research results including the statistic findings, definition of variables for which those findings apply, and the certainty of these findings; (4) assessments of research results; (5) aggregation and synthesis of research results; (6) judgments regarding evidence syntheses and contextual factors related to recommendations; (7) recommendations; and (8) compositions of combinations of these types of knowledge. The types of interoperability covered include syntactic (Resource StructureDefinitions) and semantic (value sets).",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ebm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ebm",
+      "ci-build": "http://build.fhir.org/ig/HL7/ebm",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot2",
+          "package": "hl7.fhir.uv.ebm#1.0.0-ballot2",
+          "fhir-version": [
+            "6.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/ebm/2025May"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Application Feature Framework Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "hl7.fhir.uv.application-feature",
+      "description": "This IG defines profiles and extensions to implement features that were formerly considered for what was known as CapabilityStatement2. This includes a terminology-based approach to managing new assertions around system capabilities, which will allow for feature negotiation.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/application-feature/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/application-feature",
+      "ci-build": "http://build.fhir.org/ig/HL7/capstmt",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.application-feature#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/application-feature/2024Sep"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Bulk Data Access",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.us.bulkdata",
+      "description": "This Implementation Guide defines secure FHIR export Operations that use this capability to provide an authenticated and authorized client with the ability to register as a backend service and retrieve any data in a FHIR server, data on all patients in a server, or data on a group of patients while optionally specifying data since a certain date",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/bulkdata/history.html",
+      "canonical": "http://hl7.org/fhir/us/bulkdata",
+      "ci-build": "https://build.fhir.org/ig/HL7/bulk-data",
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.us.bulkdata#0.1.0",
+          "fhir-version": [
+            "4.0.0"
+          ],
+          "url": "http://hl7.org/fhir/us/bulkdata/2019May"
+        }
+      ],
+      "analysis": {
+        "operations": 3
+      }
+    },
+    {
+      "name": "FHIR Bulk Data Access (Flat FHIR)",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.uv.bulkdata",
+      "description": "Defines a way to efficiently access large volumes of information on a group of individuals from an EHR",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/bulkdata/history.html",
+      "canonical": "http://hl7.org/fhir/uv/bulkdata",
+      "ci-build": "http://build.fhir.org/ig/HL7/bulk-data",
+      "analysis": {
+        "rest": true,
+        "operations": 3,
+        "valuesets": 1,
+        "codeSystems": 1
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 3",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.uv.bulkdata#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/bulkdata/STU3"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Clinical Documents",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.fhir.uv.fhir-clinical-document",
+      "description": "The FHIR Clinical Document Implementation Guide is a canonical representation of a clinical document in FHIR. The IG serves as a common universal starting point for those creating their own FHIR clinical document specifications, and supports those CDA users wishing to migrate to a FHIR-based representation of clinical documents.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/fhir-clinical-document/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/fhir-clinical-document",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-clinical-document/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.fhir-clinical-document#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/fhir-clinical-document/STU1"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Clinical Guidelines",
+      "category": "Quality / CDS",
+      "npm-name": "hl7.fhir.uv.cpg",
+      "description": "This implementation guide is a multi-stakeholder effort to use FHIR resources to build shareable and computable representations of the content of clinical care guidelines. The guide focuses on common patterns in clinical guidelines, establishing profiles, conformance requirements, and guidance for the patient-independent, as well as analogous patterns for the patient-specific representation of guideline recommendations",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cpg/history.html",
+      "canonical": "http://hl7.org/fhir/uv/cpg",
+      "ci-build": "http://build.fhir.org/ig/HL7/cqf-recommendations",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "medsMgmt": true,
+        "measures": true,
+        "questionnaire": true,
+        "profiles": 102,
+        "extensions": 38,
+        "operations": 5,
+        "valuesets": 9,
+        "codeSystems": 7,
+        "examples": 441
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.uv.cpg#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cpg/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.cpg#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cpg/STU1"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Core Extensions Registry",
+      "category": "Extensions",
+      "npm-name": "hl7.fhir.uv.extensions",
+      "description": "This package defines the 'core extensions' - the extensions defined globally and available to all implementers",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/extensions/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/extensions",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-extensions",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 5.3",
+          "ig-version": "5.3.0-ballot-tc1",
+          "package": "hl7.fhir.uv.extensions#5.3.0-ballot-tc1",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/extensions/5.3.0-ballot-tc1"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Data Segmentation for Privacy",
+      "category": "Privacy / Security",
+      "npm-name": "hl7.fhir.uv.security-label-ds4p",
+      "description": "Guidance for applying security labels in FHIR",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/security-label-ds4p/history.html",
+      "canonical": "http://hl7.org/fhir/uv/security-label-ds4p",
+      "ci-build": "http://hl7.org/fhir/ig/HL7/security-label-ds4p",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "extensions": 6,
+        "valuesets": 8,
+        "examples": 8
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.security-label-ds4p#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/security-label-ds4p/STU1"
+        }
+      ]
+    },
+    {
+      "name": "FHIR eMedication exchange formats for the implementation effort of CARA within its EPR community",
+      "category": "Medications / Immunizations",
+      "npm-name": "ch.fhir.ig.ch-emed-epr",
+      "description": "FHIR eMedication exchange formats for the implementation effort of CARA within its EPR community.",
+      "authority": "CARA",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-emed-epr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-emed-epr",
+      "ci-build": "http://build.fhir.org/ig/CARA-ch/ch-emed-epr",
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "ch.fhir.ig.ch-emed-epr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-emed-epr/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "FHIR for FAIR - FHIR Implementation Guide",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.fhir-for-fair",
+      "description": "The FHIR for FAIR Implementation Guide provides guidance on how the HL7 FHIR standard can be used for supporting the implementation and the assessment of the FAIR principles for health data",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/fhir-for-fair/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/fhir-for-fair",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-for-fair",
+      "analysis": {
+        "error": "Unsupported version: 4.1.0"
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.fhir-for-fair#1.0.0",
+          "fhir-version": [
+            "4.3.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/fhir-for-fair/STU1"
+        }
+      ]
+    },
+    {
+      "name": "FHIR IG Human Services Directory",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.hsds",
+      "description": "FHIR API-based data exchange enabling healthcare provider, community-based organization, payer, and consumer-facing application systems to search standardized directories of organizations providing human and social services, providing foundational support for downstream care planning and management use cases, including closed loop referrals, care coordination and care management activities, consumer-based search for assistance, etc. This guide is a US Realm specification.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/hsds/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/hsds",
+      "ci-build": "http://build.fhir.org/ig/HL7/FHIR-IG-Human-Services-Directory",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.hsds#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/hsds/STU1"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Implementation Guide for ABDM",
+      "category": "National Base",
+      "npm-name": "ndhm.in",
+      "description": "FHIR Implementation Guide for Ayushman Bharat Digital Mission",
+      "authority": "NRCeS",
+      "country": "in",
+      "history": "https://nrces.in/ndhm/fhir/r4/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://nrces.in/ndhm/fhir/r4",
+      "ci-build": "https://nrces.in/ndhm/fhir/r4",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "6.5.0",
+          "package": "ndhm.in#6.5.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://nrces.in/ndhm/fhir/r4/6.5.0"
+        }
+      ]
+    },
+    {
+      "name": "FHIR International Patient Summary (FIPS)",
+      "category": "Content Profile",
+      "npm-name": "ihe.pcc.fiio",
+      "description": "Additional options for implementing the HL7 International Patient Summary FHIR document and associated testing requirements.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/PCC/FIIO/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/PCC/FIIO",
+      "ci-build": "http://build.fhir.org/ig/IHE/PCC.FIIO/branches/master/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication Ballot",
+          "ig-version": "1.0.0-comment",
+          "package": "ihe.pcc.fiio#1.0.0-comment",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/PCC/FIIO/1.0.0-comment"
+        }
+      ]
+    },
+    {
+      "name": "FHIR Shorthand",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.uv.shorthand",
+      "description": "FHIR Shorthand (FSH) is a domain-specific language (DSL) for defining the contents of FHIR IGs to allow the author to express their intent with fewer concerns about underlying FHIR mechanics",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/shorthand/history.html",
+      "canonical": "http://hl7.org/fhir/uv/shorthand",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-shorthand",
+      "language": [
+        "en"
+      ],
+      "analysis": {},
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 3 Normative+trial-use",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.uv.shorthand#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/shorthand/N2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.shorthand#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/shorthand/STU1"
+        }
+      ]
+    },
+    {
+      "name": "FHIRcast",
+      "category": "Imaging",
+      "npm-name": "hl7.fhir.uv.fhircast",
+      "description": "Following a SMART on FHIR launch, FHIRcast enables a SMART app to subscribe to a user's session, synchronizing with other healthcare applications. Using OAuth 2.0, websockets and a few simple events: EHRs, PACS, SMART apps and other systems show the same patient (or study) to the same user at the same time. In advanced imaging integrations, the FHIRcast websocket connection is re-used by synchronized apps to collaboratively create and exchange draft image measurements and similar findings.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/fhircast/history.html",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/HL7/fhircast-docs",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 2,
+        "extensions": 1,
+        "examples": 1
+      },
+      "canonical": "http://fhircast.hl7.org",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU3 (v3.0.0)",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.uv.fhircast#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhircast.hl7.org/STU3"
+        }
+      ]
+    },
+    {
+      "name": "FHIRPath Specification",
+      "category": "Infrastructure",
+      "npm-name": "hl7.fhirpath",
+      "description": "FHIRPath specification",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhirpath/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhirpath",
+      "ci-build": "http://build.fhir.org/ig/HL7/FHIRPath",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "R2 Ballot",
+          "ig-version": "3.0.0-ballot",
+          "package": "hl7.fhirpath#3.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhirpath/2025Jan"
+        }
+      ]
+    },
+    {
+      "name": "Finnish Base Profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.fi.base",
+      "description": "A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland",
+      "authority": "HL7",
+      "country": "fi",
+      "history": "https://hl7.fi/fhir/finnish-base-profiles/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.fi/fhir/finnish-base-profiles",
+      "ci-build": "https://fhir.fi/finnish-base-profiles",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.fi.base#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.fi/fhir/finnish-base-profiles/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Finnish Implementation Guide for SMART App Launch",
+      "npm-name": "hl7.fhir.fi.smart",
+      "category": "National Base",
+      "description": "Guidelines for using the SMART App Launch mechanism in Finland, published and maintained by HL7 Finland.",
+      "authority": "HL7",
+      "country": "fi",
+      "history": "https://hl7.fi/fhir/finnish-smart/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.fi/fhir/finnish-smart",
+      "ci-build": "https://fhir.fi/finnish-smart",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.fi.smart#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.fi/fhir/finnish-smart/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Finnish Scheduling",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.fi.scheduling",
+      "description": "Finnish HL7 FHIR implementation guide for scheduling, published and maintained by HL7 Finland",
+      "authority": "HL7",
+      "country": "fi",
+      "history": "https://hl7.fi/fhir/finnish-scheduling/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.fi/fhir/finnish-scheduling",
+      "ci-build": "https://fhir.fi/finnish-scheduling",
+      "editions": [
+        {
+          "name": "STU 2 Ballot",
+          "ig-version": "2.0.0-rc3",
+          "package": "hl7.fhir.fi.scheduling#2.0.0-rc3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.fi/fhir/finnish-scheduling/2.0.0-rc3"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "FLC Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "flc.fhir.base",
+      "description": "Implementationsguide for FLC made by Service Well",
+      "authority": "Service Well",
+      "country": "uv",
+      "history": "http://canonical.fhir.link/flc/base/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://canonical.fhir.link/flc/base",
+      "ci-build": "http://build.fhir.org/ig/servicewell/flc.fhir.base",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Pre-Release Draft",
+          "ig-version": "0.2.4",
+          "package": "flc.fhir.base#0.2.4",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://canonical.fhir.link/flc/base/0.2.4"
+        }
+      ]
+    },
+    {
+      "name": "FUT Infrastructure",
+      "category": "Frameworks",
+      "npm-name": "dk.ehealth.sundhed.fhir.ig.core",
+      "description": "The Danish eHealth Infrastructure Implementation Guide defines a set of FHIR profiles with extensions and bindings needed to create interoperable, quality-focused applications.",
+      "authority": "Den telemedicinske infrastruktur",
+      "country": "dk",
+      "history": "http://ehealth.sundhed.dk/fhir/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://ehealth.sundhed.dk/fhir",
+      "ci-build": "http://build.fhir.org/ig/fut-infrastructure/implementation-guide",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "3.4.1",
+          "package": "dk.ehealth.sundhed.fhir.ig.core#3.4.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://ehealth.sundhed.dk/fhir/3.4.1"
+        },
+        {
+          "name": "Releases",
+          "ig-version": "3.4.0",
+          "package": "dk.ehealth.sundhed.fhir.ig.core#3.4.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://ehealth.sundhed.dk/fhir/3.4.0"
+        },
+        {
+          "name": "Releases",
+          "ig-version": "3.3.0",
+          "package": "dk.ehealth.sundhed.fhir.ig.core#3.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://ehealth.sundhed.dk/fhir/3.3.0"
+        },
+        {
+          "name": "Releases",
+          "ig-version": "3.2.0",
+          "package": "dk.ehealth.sundhed.fhir.ig.core#3.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://ehealth.sundhed.dk/fhir/3.2.0"
+        },
+        {
+          "name": "Releases",
+          "ig-version": "3.1.0",
+          "package": "dk.ehealth.sundhed.fhir.ig.core#3.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://ehealth.sundhed.dk/fhir/3.1.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Generic Functions for data exchange Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.nl.gf",
+      "description": "This implementation guide specifies generic functions needed for (use case specific) data exchange standards in the Netherlands. These functions cover identification, authentication, authorization, data localization, consent and a care service directory.",
+      "authority": "Ministry of Health, Welfare and Sport",
+      "country": "nl",
+      "history": "https://minvws.github.io/generiekefuncties-docs/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://minvws.github.io/generiekefuncties-docs",
+      "ci-build": "https://build.fhir.org/ig/minvws/generiekefuncties-docs",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Ballot 1",
+          "ig-version": "0.2.0-ballot",
+          "package": "hl7.fhir.nl.gf#0.2.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://build.fhir.org/ig/minvws/generiekefuncties-docs/branches/0.2.0-ballot"
+        },
+        {
+          "name": "release for hl7-nl validation",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.nl.gf#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://build.fhir.org/ig/minvws/generiekefuncties-docs/branches/v0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "Genomics Reporting",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.genomics-reporting",
+      "description": "This implementation guide tries to provide guidance that will enable improved interoperable and computable sharing of genetic testing results",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/genomics-reporting/history.html",
+      "canonical": "http://hl7.org/fhir/uv/genomics-reporting",
+      "ci-build": "http://build.fhir.org/ig/HL7/genomics-reporting",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 18,
+        "extensions": 4,
+        "operations": 1,
+        "valuesets": 10,
+        "codeSystems": 3,
+        "examples": 65
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU3",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.uv.genomics-reporting#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/genomics-reporting/STU3"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.uv.genomics-reporting#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/genomics-reporting/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.genomics-reporting#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/genomics-reporting/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Guia de Implementa\u00e7\u00e3o da SES GO - CORE",
+      "category": "Medication / Immunization",
+      "npm-name": "br.go.ses.core",
+      "description": "Guia de Implementa\u00e7\u00e3o da SES GO - CORE",
+      "authority": "Secretaria de Estado da Sa\u00fade de Goi\u00e1s",
+      "country": "br",
+      "history": "https://fhir.saude.go.gov.br/r4/core/history.html",
+      "language": [
+        "pt"
+      ],
+      "canonical": "https://fhir.saude.go.gov.br/r4/core",
+      "ci-build": "https://fhir.saude.go.gov.br/r4/core",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.0.1",
+          "package": "br.go.ses.core#0.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://fhir.saude.go.gov.br/r4/core"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Health Checkup Report Implementation Guide",
+      "category": "Clinical Documents",
+      "npm-name": "jp-eCheckupReport.r4",
+      "description": "This guide defines the FHIR data representation and associated profiles for Health Checkup Report",
+      "authority": "HL7 Japan (JAMI)",
+      "product": [
+        "fhir"
+      ],
+      "country": "jp",
+      "language": [
+        "ja"
+      ],
+      "canonical": "http://jpfhir.jp/fhir/eCheckupReport",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.6.0",
+          "package": "eCheckupReport#1.6.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://jpfhir.jp/fhir/eCheckup/igv1"
+        }
+      ]
+    },
+    {
+      "name": "Healthcare Associated Infection Reports (HAI) Long Term Care Facilities (LTCF)",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.hai-ltcf",
+      "description": "Long term care facility (LTCF) healthcare-associated infection (HAI) reporting to CDC National Healthcare Safety Network (NHSN) to track infections and prevention process measures in a systematic way, which allows identification of problems and care improvement",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/hai-ltcf/history.html",
+      "canonical": "http://hl7.org/fhir/us/hai-ltcf",
+      "analysis": {
+        "valuesets": 4,
+        "codeSystems": 2
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/HAI-LTCF",
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.hai-ltcf#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/hai-ltcf/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.hai-ltcf#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/hai-ltcf/STU1"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Allergy profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.allergy",
+      "description": "HL7 Belgium FHIR Implementation Guide - Allergy profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/allergy/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/allergy",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/allergy",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.allergy#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/allergy/1.0.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.be.allergy#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/allergy/1.0.1"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.be.allergy#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/allergy/1.1.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.2.0",
+          "package": "hl7.fhir.be.allergy#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/allergy/1.2.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Core clinical profiles - transversal",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.core-clinical",
+      "description": "HL7 Belgium FHIR Implementation Guide - Core clinical profiles - transversal",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/core-clinical/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/core-clinical",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/core-clinical",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.core-clinical#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/core-clinical/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Core profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.core",
+      "description": "HL7 Belgium FHIR Implementation Guide - Core profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/core",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/core",
+      "editions": [
+        {
+          "name": "Trial Use Test",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.be.core#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/core/2.0.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "2.0.1",
+          "package": "hl7.fhir.be.core#2.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/core/2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Digital Referral Prescription profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.drp",
+      "description": "HL7 Belgium FHIR Implementation Guide - Digital Referral Prescription profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/drp/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/drp",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/referral",
+      "editions": [
+        {
+          "name": "Trial Use Test",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.drp#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/drp/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Lab related profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.lab",
+      "description": "HL7 Belgium FHIR Implementation Guide - Lab related profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/lab/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/lab",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/lab",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.lab#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/lab/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Medication profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.medication",
+      "description": "HL7 Belgium FHIR Implementation Guide - Medication profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/medication/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/medication",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/medication",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.medication#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/medication/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - MyCareNet profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.mycarenet",
+      "description": "HL7 Belgium FHIR Implementation Guide - MyCareNet profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/mycarenet/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/mycarenet",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/mycarenet",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.be.mycarenet#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/mycarenet/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Patient Dossier profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.patient-dossier",
+      "description": "HL7 Belgium FHIR Implementation Guide - Patient Dossier profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/patient-dossier/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/patient-dossier",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/patient-dossier",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.patient-dossier#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/patient-dossier/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Prescription Search Support profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.pss",
+      "description": "HL7 Belgium FHIR Implementation Guide - Prescription Search Support profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/pss/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/pss",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/pss",
+      "editions": [
+        {
+          "name": "Trial Use Test",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.pss#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/pss/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Belgium FHIR Implementation Guide - Vaccination profiles",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.vaccination",
+      "description": "HL7 Belgium FHIR Implementation Guide - Vaccination profiles",
+      "authority": "eHealth Platform (BE)",
+      "product": [
+        "fhir"
+      ],
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/vaccination/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/vaccination",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/vaccination",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 6,
+        "extensions": 1,
+        "valuesets": 3,
+        "codeSystems": 5,
+        "examples": 6
+      },
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.vaccination#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.be.vaccination#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.1"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.2",
+          "package": "hl7.fhir.be.vaccination#1.0.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.2"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.3",
+          "package": "hl7.fhir.be.vaccination#1.0.3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.3"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Cross Paradigm IG: Gender Harmony - Sex and Gender Representation",
+      "category": "Administration",
+      "npm-name": "hl7.xprod.uv.gender-harmony",
+      "description": "Provide profile components and guidance on how to properly represent Gender Identity as distinct from clinical sex characterization via Sex For Clinical Use, as well as other aligned sex- or gender-related data elements (Recorded Sex or Gender, Name to Use, Pronouns, etc.) Covers implementation approaches for FHIR, CDA, and V2.",
+      "authority": "HL7",
+      "product": [
+        "fhir",
+        "cda",
+        "v2"
+      ],
+      "country": "uv",
+      "history": "http://hl7.org/xprod/ig/uv/gender-harmony/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/xprod/ig/uv/gender-harmony",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-gender-harmony",
+      "editions": [
+        {
+          "name": "Informative Edition 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.xprod.uv.gender-harmony#1.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/xprod/ig/uv/gender-harmony/informative1"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Czech FHIR Terminology",
+      "category": "Terminology",
+      "npm-name": "hl7.fhir.cz.terminology",
+      "description": "HL7 and NCEZ FHIR Terminology for the Czech Republic.",
+      "authority": "HL7 Czech Republic",
+      "country": "cz",
+      "history": "https://hl7.cz/terminology/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://hl7.cz/terminology",
+      "ci-build": "http://build.fhir.org/ig/HL7-cz/terminology",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.cz.terminology#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://hl7.cz/terminology/0.2.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 EHR-S FM R2.1.1 - Dental Health Functional Profile, Release 2",
+      "category": "EHR-S Family",
+      "npm-name": "hl7.ehrs.us.dhfpr2",
+      "description": "The DHFP is based on the HL7 Electronic Health Record System Functional Model and Standard (EHR-S FM) Release 2.01, July 2017. The DHFP is intended to inform software developers, users, purchasers, and other interested parties, such as payers and data aggregators, regarding the desired performance of a dental electronic health record software system, whether operating stand-alone or integrated with a medical electronic health record system. The DHFP is an informative technical report intended for use in the United States Realm",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/ehrs/us/dhfpr2/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/ehrs/us/dhfpr2",
+      "ci-build": "http://build.fhir.org/ig/HL7/dhfp-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Informative Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.ehrs.us.dhfpr2#2.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/ehrs/us/dhfpr2/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Electronic Health Record System Functional Model, Release 2.1.1",
+      "category": "EHR-S Family",
+      "npm-name": "hl7.ehrs.uv.ehrsfmr2",
+      "description": "Electronic Health Record System Functional Model",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/ehrs/uv/ehrsfmr2/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/ehrs/uv/ehrsfmr2",
+      "ci-build": "http://build.fhir.org/ig/HL7/ehrsfm-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Normative 1 Ballot",
+          "ig-version": "2.1.1-ballot",
+          "package": "hl7.ehrs.uv.ehrsfmr2#2.1.1-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/ehrs/uv/ehrsfmr2/2025May"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Base and Core (R4)",
+      "category": "Regional Base",
+      "npm-name": "hl7.fhir.eu.base",
+      "description": "This guide lists the base and core profiles - FHIR R4 - specified for the European REALM.",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/base/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/base",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/base",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2.0 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.eu.base#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/base/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Base and Core (R5)",
+      "category": "Regional Base",
+      "npm-name": "hl7.fhir.eu.base-r5",
+      "description": "This guide lists the base and core profiles  - FHIR R5 - specified for the European REALM.",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/base-r5/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/base-r5",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/base-r5",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2.0 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.eu.base-r5#2.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.eu/fhir/base-r5/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Extensions",
+      "category": "Extensions",
+      "npm-name": "hl7.fhir.eu.extensions",
+      "description": "This guide lists the extensions specified for the European REALM.",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/extensions/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/extensions",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/extensions",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.3.0",
+          "package": "hl7.fhir.eu.extensions#1.3.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.eu/fhir/extensions/1.3.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Hospital Discharge Report",
+      "category": "Discharge Report",
+      "npm-name": "hl7.fhir.eu.hdr",
+      "description": "This implementation guide specifies the Hospital Discharge Report in the European context, as defined in eHN Hospital Discharge Report guidelines.",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/hdr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/hdr",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/hdr",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0-ballot",
+          "package": "hl7.fhir.eu.hdr#0.1.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/hdr/0.1.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Imaging Report",
+      "category": "Imaging",
+      "npm-name": "hl7.fhir.eu.imaging",
+      "description": "This implementation guide specifies imaging study data in the European context, as defined in eHN Imaging Studies and Reports and refined by XtEHR Imaging Logical Model, as a FHIR model.",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/imaging/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/imaging",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/imaging-r4",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.eu.imaging#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/imaging/1.0.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Imaging Study Report",
+      "category": "Imaging",
+      "npm-name": "hl7.fhir.eu.imaging-r5",
+      "description": "This implementation guide specifies imaging study data in the European context, as defined in eHN Imaging Studies and Reports and refined by XtEHR Imaging Logical Model, as a FHIR model.",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/imaging-r5/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/imaging-r5",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/imaging-r5",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.eu.imaging-r5#1.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.eu/fhir/imaging-r5/1.0.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Laboratory Report",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.eu.laboratory",
+      "description": "This guide defines a set of common rules to be applied to HL7 FHIR to represent a Laboratory Report in the European Context, coherently with the European eHN Guidelines",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/laboratory/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/laboratory",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/laboratory",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.1",
+          "ig-version": "0.1.1",
+          "package": "hl7.fhir.eu.laboratory#0.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/laboratory/0.1.1"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Medication Prescription and Dispense",
+      "category": "Medication Management",
+      "npm-name": "hl7.fhir.eu.mpd",
+      "description": "This guide describes how to represent in HL7 FHIR Prescription and Dispense in the European context. (FHIR R4)",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/mpd/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/mpd",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/mpd",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0-ballot",
+          "package": "hl7.fhir.eu.mpd#0.1.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/mpd/0.1.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Europe Medication Prescription and Dispense",
+      "category": "Medication Management",
+      "npm-name": "hl7.fhir.eu.mpd-r5",
+      "description": "This guide describes how to represent in HL7 FHIR Prescription and Dispense in the European context. (FHIR R5)",
+      "authority": "HL7 Europe",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/mpd-r5/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/mpd-r5",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/mpd-r5",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0-ballot",
+          "package": "hl7.fhir.eu.mpd-r5#0.1.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.eu/fhir/mpd-r5/0.1.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "HL7 FHIR Implementation Guide for Military Service History and Status",
+      "category": "Clinical Observations",
+      "npm-name": "hl7.fhir.us.military-service",
+      "description": "Supports Military Service History and Status reporting consistent with US regulatory requirements (i.e. Title 38 Veteran Benefits)",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/military-service/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/military-service",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-military-service",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 5,
+        "extensions": 1,
+        "operations": 1,
+        "valuesets": 7,
+        "codeSystems": 1,
+        "examples": 5
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.military-service#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/military-service/STU1"
+        }
+      ]
+    },
+    {
+      "name": "HL7 FHIR Implementation Guide Laboratory Report",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.it.lab-report",
+      "description": "This guide defines a set of common rules to be applied to HL7 FHIR to represent a Laboratory Report in the Italian Context, coherently with the European FHIR Implementation Guide",
+      "authority": "HL7 Italia",
+      "country": "it",
+      "history": "http://hl7.it/fhir/lab-report/history.html",
+      "language": [
+        "it"
+      ],
+      "canonical": "http://hl7.it/fhir/lab-report",
+      "ci-build": "http://build.fhir.org/ig/hl7-it/lab-report",
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.it.lab-report#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.it/fhir/lab-report/0.2.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "HL7 FHIR Implementation Guide: DK SMART",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.dk.smart",
+      "description": "Base danish national implementation guide for SMART",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://hl7.dk/fhir/smart/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.dk/fhir/smart",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/dk-smart",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.dk.smart#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.dk/fhir/smart/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 FHIR Implementation Guide: Public Health IG Release 1 - BE Realm | STU1",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.public-health",
+      "description": "HL7 FHIR Implementation Guide: Public Health IG Release 1 - BE Realm | STU1",
+      "authority": "eHealth Platform Belgium",
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/public-health/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/public-health",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/public-health",
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.public-health#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/public-health/1.0.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.2",
+          "package": "hl7.fhir.be.public-health#1.0.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/public-health/1.0.2"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "HL7 FHIR\u00ae Implementation Guide: Ophthalmology Retinal, Release 1",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.eyecare",
+      "description": "Provides representation of ophthalmic domain and related clinical and administrative data elements in the FHIR format to support effective collaborative and continuity of care of patients suffering from eye conditions. ",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/eyecare/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/eyecare",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-eyecare-ig",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "diagnostics": true,
+        "profiles": 15,
+        "valuesets": 13,
+        "codeSystems": 3,
+        "examples": 32
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.uv.eyecare#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/eyecare/2021Sep"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Informative Document: Patient Information Quality Improvement (PIQI) Framework, Edition 1",
+      "category": "Frameworks",
+      "npm-name": "hl7.xprod.uv.piqi",
+      "description": "The Patient Information Quality Improvement Framework or PIQI Framework (pronounced \u2018picky\u2019) creates a standard approach to evaluating data quality of patient-centric healthcare information. PIQI prioritizes portability and reusability, enabling seamless integration into various systems irrespective of the data source.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/xprod/ig/uv/piqi/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/xprod/ig/uv/piqi",
+      "ci-build": "http://build.fhir.org/ig/HL7/piqi",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Informative 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.xprod.uv.piqi#1.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/xprod/ig/uv/piqi/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Italia FHIR Implementation Guide (base)",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.it.base",
+      "description": "This guide describes a set of FHIR base profiles and reference logical models to be used in the Italian context",
+      "authority": "HL7 Italia",
+      "product": [
+        "fhir"
+      ],
+      "country": "it",
+      "history": "http://hl7.it/fhir/history.html",
+      "canonical": "http://hl7.it/fhir/base",
+      "ci-build": "http://hl7.it/fhir/base",
+      "language": [
+        "it"
+      ],
+      "editions": [
+        {
+          "name": "Initial Public Comment ballot (Jun 2020 Ballot)",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.it.base#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.it/fhir/base/2020-06"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id hl7.fhir.it.base#0.1.0"
+      }
+    },
+    {
+      "name": "HL7 Laboratory Report",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.lab-report",
+      "description": "Universal implementation guide for laboratory reporting using FHIR (based on FHIR document or DiagnosticReport)",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/lab-report/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/lab-report",
+      "ci-build": "http://build.fhir.org/ig/HL7/uv-lab-rep-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.lab-report#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/lab-report/2024Sep"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Norway no-basis",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.no.basis",
+      "description": "HL7 FHIR Base profiles for Norway",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "no",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.no/fhir",
+      "editions": [
+        {
+          "name": "HL7 Norway no-basis",
+          "ig-version": "2.2.2",
+          "package": "hl7.fhir.no.basis#2.2.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://simplifier.net/guide/no-basis-entities-individuals?version=current"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 20,
+        "extensions": 13,
+        "valuesets": 7,
+        "codeSystems": 4
+      }
+    },
+    {
+      "name": "HL7 Personal Health Record System Functional Model, Release 2",
+      "category": "EHR-S Family",
+      "npm-name": "hl7.ehrs.uv.phrsfmr2",
+      "description": "Personal Health Record System Functional Model",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/ehrs/uv/phrsfmr2/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/ehrs/uv/phrsfmr2",
+      "ci-build": "http://build.fhir.org/ig/HL7/phrsfm-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Normative 1 Ballot",
+          "ig-version": "2.0.1-ballot",
+          "package": "hl7.ehrs.uv.phrsfmr2#2.0.1-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/ehrs/uv/phrsfmr2/2025May"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Sweden base profiles",
+      "category": "National Base",
+      "npm-name": "hl7se.fhir.base",
+      "description": "Implementation Guide for Swedish Base Profiles",
+      "authority": "HL7 Sweden",
+      "country": "se",
+      "history": "http://hl7.se/fhir/ig/base/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.se/fhir/ig/base",
+      "ci-build": "http://build.fhir.org/ig/HL7Sweden/basprofiler-r4",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "hl7se.fhir.base#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.se/fhir/ig/base/1.0.0"
+        },
+        {
+          "name": "Releases",
+          "ig-version": "1.1.0",
+          "package": "hl7se.fhir.base#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.se/fhir/ig/base/1.1.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "HL7 Terminology",
+      "category": "Terminology",
+      "npm-name": "hl7.terminology",
+      "description": "Terminology",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://terminology.hl7.org/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://terminology.hl7.org",
+      "ci-build": "http://build.fhir.org/ig/HL7/UTG",
+      "analysis": {
+        "content": true,
+        "extensions": 9,
+        "valuesets": 2483,
+        "codeSystems": 1078
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publications",
+          "ig-version": "7.1.0",
+          "package": "hl7.terminology#7.1.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://terminology.hl7.org/7.1.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Terminology Ecosystem IG",
+      "category": "Infrastructure",
+      "npm-name": "hl7.fhir.uv.tx-ecosystem",
+      "description": "Terminology Ecosystem documentation and test cases",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/tx-ecosystem/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/tx-ecosystem",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-tx-ecosystem-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases Informative",
+          "ig-version": "1.8.0",
+          "package": "hl7.fhir.uv.tx-ecosystem#1.8.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/tx-ecosystem/1.8.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7 Tools Extension IG",
+      "category": "Infrastructure",
+      "npm-name": "hl7.fhir.uv.tools",
+      "description": "Definitions of the code systems and extensions used by the FHIR tools (validators, code generators, IG publication, etc)",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/tools/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/tools",
+      "ci-build": "http://build.fhir.org/ig/FHIR/fhir-tools-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release Informative",
+          "ig-version": "1.1.2",
+          "package": "hl7.fhir.uv.tools#1.1.2",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/tools/1.1.2"
+        }
+      ]
+    },
+    {
+      "name": "HL7 UK FHIR UKCore Implementation Guide",
+      "category": "National Base",
+      "npm-name": "fhir.r4.ukcore.stu3.currentbuild",
+      "description": "HL7 UK FHIR UKCore Implementation Guide",
+      "authority": "HL7 UK",
+      "country": "gb",
+      "history": "https://simplifier.net/guide/ukcoreversionhistory/home?version=current",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence?version=current",
+      "editions": [
+        {
+          "name": "STU 3",
+          "ig-version": "0.0.18-pre-release",
+          "package": "fhir.r4.ukcore.stu3.currentbuild 0.0.18-pre-release",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://simplifier.net/guide/UK-Core-Implementation-Guide-STU3-Sequence/Home?version=current"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.1",
+          "package": "fhir.r4.ukcore.stu2 2.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://simplifier.net/guide/uk-core-implementation-guide-stu2?version=2.0.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "fhir.r4.ukcore.stu1 1.0.4",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://simplifier.net/guide/uk-core-implementation-guide?version=1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "HL7 Version 2 to FHIR",
+      "npm-name": "hl7.fhir.uv.v2mappings",
+      "description": "The HL7 V2 to FHIR Implementation Guide supports the mapping of HL7 Version 2 messages segments, datatypes and vocabulary to HL7 FHIR Release 4.0 Bundles, Resources, Data Types and Coding Systems.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/v2mappings/history.html",
+      "canonical": "http://hl7.org/fhir/uv/v2mappings",
+      "ci-build": "http://build.fhir.org/ig/HL7/v2-to-fhir",
+      "language": [
+        "en"
+      ],
+      "category": "Mappings to Other Standards",
+      "analysis": {
+        "content": true,
+        "extensions": 57,
+        "examples": 175
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.v2mappings#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/v2mappings/STU1"
+        }
+      ]
+    },
+    {
+      "name": "HL7\u00ae Austria FHIR\u00ae Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.at.fhir.core.r5",
+      "description": "A FHIR\u00ae Implementation Guide for the HL7\u00ae Austria FHIR\u00ae Core Profiles.",
+      "authority": "HL7 Austria",
+      "country": "at",
+      "history": "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0",
+      "ci-build": "http://build.fhir.org/ig/HL7Austria/HL7-AT-FHIR-Core-R5",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.at.fhir.core.r5#2.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "HL7\u00ae Austria FHIR\u00ae Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.at.fhir.core.r4",
+      "description": "A FHIR\u00ae Implementation Guide for the HL7\u00ae Austria FHIR\u00ae Core Profiles.",
+      "authority": "HL7 Austria",
+      "country": "at",
+      "history": "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1",
+      "ci-build": "http://build.fhir.org/ig/HL7Austria/HL7-AT-FHIR-Core-R4",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.at.fhir.core.r4#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "How to Publish a FHIR Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "ca.argentixinfo.howtopub",
+      "description": "An instruction guide showing how to use the HL7 IG Publisher's -go-publish feature to publish an implementation guide to a website.",
+      "authority": "Argentix Informatics, Inc.",
+      "country": "ca",
+      "history": "http://argentixinfo.com/ig/howtopub/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://argentixinfo.com/ig/howtopub",
+      "ci-build": "http://build.fhir.org/ig/ElliotSilver/how-to-publish",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 1",
+          "ig-version": "1.1.0",
+          "package": "ca.argentixinfo.howtopub#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://argentixinfo.com/ig/howtopub/1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "HRSA Uniform Data System (UDS) Patient Level Submission (PLS) (UDS+ or uds-plus) FHIR IG",
+      "category": "Surveillience / Reporting",
+      "npm-name": "fhir.hrsa.uds-plus",
+      "description": "UDS+ is part of HRSA`s modernization initiatives and requires health centers to report data annually as part of the funding grants. UDS is a standard data set that provides consistent information about Federally Qualified Health Centers. It is the source of non duplicated data for the entire scope of services included in the grant or designation for the calendar year. HRSA uses UDS data to assess the impact and performance of the Health Center Program, and to promote data-driven quality improvement",
+      "authority": "US Government",
+      "country": "us",
+      "history": "http://fhir.org/guides/hrsa/uds-plus/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.org/guides/hrsa/uds-plus",
+      "ci-build": "http://build.fhir.org/ig/drajer-health/uds-plus",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "fhir.hrsa.uds-plus#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.org/guides/hrsa/uds-plus/STU2"
+        }
+      ]
+    },
+    {
+      "name": "HSPC EHR Guide",
+      "category": "EHR Access",
+      "npm-name": "fhir.hspc.core",
+      "description": "Builds on Argonaut to make agreements around consistent data (in progress)",
+      "authority": "HSPC (USA)",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://fhir.org/guides/hspc/core/history.html",
+      "canonical": "http://fhir.org/guides/hspc/core",
+      "ci-build": "http://build.fhir.org/ig/hspc/core",
+      "editions": [],
+      "analysis": {}
+    },
+    {
+      "name": "Hybrid / Intermediary Exchange",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.us.exchange-routing",
+      "description": "This IG is meant to define the standard for how providers, payers, intermediaries, and other actors will use  routing information about the transaction originator and destination to support a hybrid model of point-to-point interaction as well as intermediary brokered interactions without the actors in either side needing detailed knowledge of how intermediary routing works.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/exchange-routing/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/exchange-routing",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-exchange-routing-ig",
+      "analysis": {
+        "rest": true
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.exchange-routing#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/exchange-routing/STU1"
+        }
+      ]
+    },
+    {
+      "name": "ICHOM breast cancer patient-centered outcome measure set FHIR IG",
+      "category": "Quality / CDS",
+      "npm-name": "hl7.fhir.uv.ichom-breast-cancer",
+      "description": "This Implementation Guide describes the representation of the ICHOM Breast Cancer Patient Centered Outcomes Measures in HL7 FHIR and a description of the use cases for which these are be intended to be used.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ichom-breast-cancer/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ichom-breast-cancer",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-ichom-breast-cancer-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.ichom-breast-cancer#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/ichom-breast-cancer/STU1"
+        }
+      ]
+    },
+    {
+      "name": "IClaim",
+      "category": "Financial",
+      "npm-name": "tw.cathay.fhir.iclaim",
+      "description": "Guidelines for Medical Insurance Claims Implementation",
+      "authority": "\u570b\u6cf0\u7d9c\u5408\u91ab\u9662",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://claim.cgh.org.tw/iclaim/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://claim.cgh.org.tw/iclaim",
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "tw.cathay.fhir.iclaim#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://claim.cgh.org.tw/iclaim/1.0.0"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "0.1.3",
+          "package": "tw.cathay.fhir.iclaim#0.1.3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://claim.cgh.org.tw/iclaim/0.1.3"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "0.1.2",
+          "package": "tw.cathay.fhir.iclaim#0.1.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://claim.cgh.org.tw/iclaim/0.1.2"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "0.1.1",
+          "package": "tw.cathay.fhir.iclaim#0.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://claim.cgh.org.tw/iclaim/0.1.1"
+        },
+        {
+          "name": "Trial Use",
+          "ig-version": "0.1.0",
+          "package": "tw.cathay.fhir.iclaim#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://claim.cgh.org.tw/iclaim/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "IG Tooling by GKL",
+      "category": "Research",
+      "npm-name": "hl7.at.fhir.gkl.ig-tooling",
+      "description": "This IG is built in order to describe the IG tooling.",
+      "country": "at",
+      "authority": "Unspecified",
+      "history": "https://gabriel0316.github.io/ig-tooling-pages/ig/ig-tooling/history.html",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/gabriel0316/ig-tooling",
+      "canonical": "https://gabriel0316.github.io/ig-tooling-pages/ig/ig-tooling-test",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "DSTU 1",
+          "ig-version": "0.5.3",
+          "package": "hl7.at.fhir.gkl.ig-tooling#0.5.3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://gabriel0316.github.io/ig-tooling-pages/ig/ig-tooling-test/0.5.3"
+        }
+      ]
+    },
+    {
+      "name": "IHE Assessment Curation and Data Collection (ACDC)",
+      "category": "EHR Access",
+      "npm-name": "ihe.iti.acdc",
+      "description": "Enables assessment developers and curators a means by which they can distribute assessment instruments to healthcare providers, supporting exchange of assessment data in a standardized form using the HL7 FHIR Questionnaire resource.",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "https://wiki.ihe.net/index.php/Assessment_Curation_and_Data_Collection",
+      "canonical": "https://wiki.ihe.net/index.php/Assessment_Curation_and_Data_Collection",
+      "editions": [
+        {
+          "name": "R4 Trial-Implementation",
+          "ig-version": "1.1.0",
+          "package": "ihe.pcc.acdc#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://wiki.ihe.net/index.php/Assessment_Curation_and_Data_Collection"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.acdc#1.1.0"
+      }
+    },
+    {
+      "name": "IHE Basic Audit Log Patterns (BALP)",
+      "category": "Privacy / Security",
+      "npm-name": "ihe.iti.balp",
+      "description": "The Basic Audit Log Patterns (BALP) **Content Profile** defines some basic and reusable AuditEvent patterns. This includes basic audit log profiles for FHIR RESTful operations, to be used when there is not a more specific audit event defined. Where a more specific audit event can be defined it should be derived off of these basic patterns.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/BALP/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/BALP",
+      "analysis": {
+        "content": true,
+        "profiles": 20,
+        "extensions": 2,
+        "valuesets": 6,
+        "codeSystems": 5,
+        "examples": 63
+      },
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.BasicAudit/branches/main/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.1.4",
+          "package": "ihe.iti.balp#1.1.4",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/BALP/1.1.4"
+        }
+      ]
+    },
+    {
+      "name": "IHE Birth and Fetal Death Reporting - Enhanced (BFDE)",
+      "category": "Medication / Immunization",
+      "npm-name": "ihe.pcc.bfde",
+      "description": "Provides means for pre-populating of data from electronic health record systems to electronic vital records systems for birth and fetal death reporting",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Birth_and_Fetal_Death_Reporting_Enhanced_Profile",
+      "canonical": "http://wiki.ihe.net/index.php/Birth_and_Fetal_Death_Reporting_Enhanced_Profile",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pcc.bfde#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Birth_and_Fetal_Death_Reporting_Enhanced_Profile"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.bfde#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Dynamic Care Planning (DCP)",
+      "category": "Care Management",
+      "npm-name": "ihe.pcc.dcp",
+      "description": "Provides the structures and transactions for care planning, sharing Care Plans that meet the needs of many, such as providers, patients and payers",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Dynamic_Care_Planning",
+      "canonical": "http://wiki.ihe.net/index.php/Dynamic_Care_Planning",
+      "editions": [
+        {
+          "name": "R4 Trial-Implementation",
+          "ig-version": "0.2.0",
+          "package": "ihe.pcc.dcp#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Dynamic_Care_Planning"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.dcp#0.2.0"
+      }
+    },
+    {
+      "name": "IHE Dynamic Care Team Management (DCTM)",
+      "category": "Care Management",
+      "npm-name": "ihe.pcc.dctm",
+      "description": "Provides the means for sharing care team information about a patient\u2019s care teams that meet the needs of many users, such as providers, patients and payers",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Dynamic_Care_Team_Management",
+      "canonical": "http://wiki.ihe.net/index.php/Dynamic_Care_Team_Management",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.2.0",
+          "package": "ihe.pcc.dctm#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Dynamic_Care_Team_Management"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.dctm#0.2.0"
+      }
+    },
+    {
+      "name": "IHE FHIR AuditEvent query and feed to ATNA",
+      "category": "Privacy / Security",
+      "npm-name": "ihe.iti.atna",
+      "description": "Enable audit log recording (feed) and access to ATNA Audit Repository queries using FHIR AuditEvent resource",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "https://wiki.ihe.net/index.php/Audit_Trail_and_Node_Authentication",
+      "canonical": "https://wiki.ihe.net/index.php/Audit_Trail_and_Node_Authentication",
+      "editions": [
+        {
+          "name": "R4 Trial-Implementation",
+          "ig-version": "0.2.0",
+          "package": "ihe.iti.atna#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://wiki.ihe.net/index.php/Audit_Trail_and_Node_Authentication"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.iti.atna#0.2.0"
+      }
+    },
+    {
+      "name": "IHE FHIR Profile: Occupational Data for Health (ODH) - International",
+      "category": "Clinical Observations",
+      "npm-name": "ihe.pcc.odh",
+      "description": "This IG covers the specific data that covers past or present jobs, usual work, employment status, retirement date and combat zone period for the subject. It also includes the past or present jobs and usual work of other household members. This IG is International scope",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/PCC/ODH/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/PCC/ODH",
+      "ci-build": "http://build.fhir.org/ig/IHE/PCC.ODH/branches/master/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.pcc.odh#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/PCC/ODH/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE FormatCode vocabulary",
+      "category": "EHR Access",
+      "npm-name": "ihe.formatcode.fhir",
+      "description": "Defines IHE vocabulary for FormatCode and the IHE managed ValueSet for FormatCode for use with Document Sharing such as XDS, XCA, XDM, XDR, and MHD.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "http://profiles.ihe.net/fhir/ihe.formatcode.fhir/history.html",
+      "ci-build": "http://build.fhir.org/ig/IHE/FormatCode",
+      "canonical": "https://profiles.ihe.net/fhir/ihe.formatcode.fhir",
+      "analysis": {
+        "valuesets": 1,
+        "codeSystems": 1
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication Normative",
+          "ig-version": "1.5.0",
+          "package": "ihe.formatcode.fhir#1.5.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/fhir/ihe.formatcode.fhir/1.5.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Interactive Multimedia Report (IMR)",
+      "category": "Imaging",
+      "npm-name": "ihe.rad.imr",
+      "description": "Support encoding and presentation of an interactive multimedia report",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "history": "https://profiles.ihe.net/RAD/IMR/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/RAD/IMR",
+      "ci-build": "http://build.fhir.org/ig/IHE/RAD.IMR",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "diagnostics": true,
+        "profiles": 8,
+        "extensions": 2,
+        "valuesets": 7,
+        "examples": 19
+      },
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.1.0",
+          "package": "ihe.rad.imr#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/RAD/IMR/1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE ITI Finance and Insurance Services",
+      "category": "Financial",
+      "npm-name": "ihe.iti.fais",
+      "description": "The Finance and Insurance Service (FAIS) stores, categorizes, and facilitates the administration of centralized claims and finance data for patient care. The service receives claims/financial data from Point of Service applications (including financing applications acting as a point of service interface outside of other PoS systems) and curates the management of them.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/FAIS/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/FAIS",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.Finance ",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.iti.fais#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/FAIS/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE ITI Scheduling",
+      "category": "Administration",
+      "npm-name": "ihe.iti.scheduling",
+      "description": "The IHE FHIR Scheduling Profile is a specification providing FHIR APIs and guidance for access to and booking of appointments for patients by both patient and practitioner end users. This specification is based on FHIR Version 4 and specifically the Schedule, Slot, and Appointment resources, and on the previous work of the [Argonaut Project](https://fhir.org/guides/argonaut/scheduling/release1/)",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/Scheduling/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/Scheduling",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.Scheduling",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.iti.scheduling#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/Scheduling/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Mobile Access to Health Documents (MHD)",
+      "category": "EHR Access",
+      "npm-name": "ihe.iti.mhd",
+      "description": "Defines a simple HTTP interface to a Document Sharing environment, including: publishing/query (XDS-on-FHIR), point-to-point push (XDR, Direct, XDM), and federation of communities (XCA).",
+      "authority": "IHE",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "https://profiles.ihe.net/ITI/MHD/history.html",
+      "canonical": "https://profiles.ihe.net/ITI/MHD",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.MHD",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "profiles": 24,
+        "extensions": 4,
+        "valuesets": 3,
+        "codeSystems": 1,
+        "examples": 48
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "FHIR R5",
+          "ig-version": "5.0.0",
+          "package": "ihe.iti.mhd#5.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://profiles.ihe.net/ITI/MHD/5.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Mobile Aggregate Data Exchange (mADX)",
+      "category": "EHR Access",
+      "npm-name": "ihe.qrph.madx",
+      "description": "Supports interoperable public health reporting of aggregate health data.",
+      "authority": "IHE",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "https://wiki.ihe.net/index.php/Mobile_Aggregate_Data_Exchange_(mADX)",
+      "analysis": {
+        "error": "Unable to resolve package id ihe.qrph.madx#0.1.0"
+      },
+      "canonical": "https://profiles.ihe.net/QRPH/mADX",
+      "ci-build": "http://build.fhir.org/ig/IHE/QRPH.mADX/branches/master/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "3.0.0",
+          "package": "ihe.qrph.madx#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/QRPH/mADX/3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Mobile Alert Communication Management(mACM)",
+      "category": "Communications",
+      "npm-name": "ihe.iti.macm",
+      "description": "Provides the infrastructural components needed to send short, unstructured text alerts to human recipients and can record the outcomes of any human interactions upon receipt of the alert. ",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Mobile_Alert_Communication_Management(mACM)",
+      "canonical": "http://wiki.ihe.net/index.php/Mobile_Alert_Communication_Management(mACM)",
+      "editions": [
+        {
+          "name": "R4 Trial-Implementation",
+          "ig-version": "0.2.0",
+          "package": "ihe.iti.macm#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Mobile_Alert_Communication_Management(mACM)"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.iti.macm#0.2.0"
+      }
+    },
+    {
+      "name": "IHE Mobile Care Services Discovery (mCSD)",
+      "category": "Administration",
+      "npm-name": "ihe.iti.mcsd",
+      "description": "The IHE Mobile Care Services Discovery (mCSD) IG provides a transaction for mobile and lightweight browser-based applications to find and update care services resources.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "http://profiles.ihe.net/ITI/mCSD/history.html",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.mCSD/branches/main",
+      "canonical": "https://profiles.ihe.net/ITI/mCSD",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 14,
+        "extensions": 2,
+        "valuesets": 3,
+        "codeSystems": 3,
+        "examples": 21
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "4.0.0",
+          "package": "ihe.iti.mcsd#4.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/mCSD/4.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Mobile Cross-Enterprise Document Data Element Extraction (mXDE)",
+      "category": "Clinical Documents",
+      "npm-name": "ihe.iti.mxde",
+      "description": "Provides the means to access data elements extracted from shared structured documents",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Mobile_Cross-Enterprise_Document_Data_Element_Extraction",
+      "analysis": {
+        "error": "Unable to resolve package id ihe.iti.mxde#0.1.2"
+      },
+      "canonical": "https://profiles.ihe.net/ITI/mXDE",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.mXDE/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.3.0",
+          "package": "ihe.iti.mxde#1.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/mXDE/1.3.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Mobile Health Document Sharing (MHDS)",
+      "category": "Clinical Documents",
+      "npm-name": "ihe.iti.mhds",
+      "description": "This Implementation Guide shows how to build a Document Sharing Exchange using IHE-profiled FHIR standard, rather than the legacy IHE profiles that are dominated by XDS and HL7 v2. This Implementation Guide assembles other IHE Implementation guides (Profiles) and defines a Document Registry Actor.",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "history": "http://profiles.ihe.net/ITI/MHDS/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/MHDS",
+      "analysis": {
+        "rest": true
+      },
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.MHDS/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "2.3.1",
+          "package": "ihe.iti.mhds#2.3.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/MHDS/2.3.1"
+        }
+      ]
+    },
+    {
+      "name": "IHE Mobile Medication Administration (MMA)",
+      "category": "Medications / Immunizations",
+      "npm-name": "ihe.pharm.mma",
+      "description": "Defines the integration between healthcare systems and mobile (or any other) clients using RESTful web services. This allows connecting EHRs with smartphones, smart pill boxes, and other personal or professional devices",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Mobile_Medication_Administration",
+      "canonical": "http://wiki.ihe.net/index.php/Mobile_Medication_Administration",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pharm.mma#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Mobile_Medication_Administration"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pharm.mma#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Mobile Retrieve Form for Data Capture (mRFD)",
+      "category": "Forms Management",
+      "npm-name": "ihe.qrph.mrfd",
+      "description": "Provides a method for gathering data within a user\u2019s current application to meet the requirements of an external system. mRFD supports RESTful retrieval of forms from a form source, display and completion of a form, and return of instance data from the display application to the source application. The workflows defined in this profile are based on those defined by the Retrieve Form for Data Capture (RFD) profile",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Mobile_Retrieve_Form_for_Data_Capture",
+      "canonical": "http://wiki.ihe.net/index.php/Mobile_Retrieve_Form_for_Data_Capture",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.qrph.mrfd#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Mobile_Retrieve_Form_for_Data_Capture"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.qrph.mrfd#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Non-Patient File Sharing (NPFS)",
+      "category": "Administration",
+      "npm-name": "ihe.iti.npfs",
+      "description": "Defines how to enable the sharing of non-patient files such as workflow definitions, privacy policies, blank forms, and stylesheets",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Non-patient_File_Sharing_(NPFS)",
+      "analysis": {
+        "error": "Unable to resolve package id ihe.iti.npfs#0.2.0"
+      },
+      "canonical": "https://profiles.ihe.net/ITI/NPFS",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.NPFS/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "2.2.0",
+          "package": "ihe.iti.npfs#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/NPFS/2.2.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Paramedicine Care Summary (PCS)",
+      "category": "Communications",
+      "npm-name": "ihe.pcc.pcs",
+      "description": "Provides means for Emergency Transport to inform destination Hospital with critical and necessary medical information on patient being transported",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Paramedicine_Care_Summary",
+      "canonical": "http://wiki.ihe.net/index.php/Paramedicine_Care_Summary",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pcc.pcs#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Paramedicine_Care_Summary"
+        }
+      ],
+      "analysis": {
+        "error": "Error fetching package directly (https://profiles.ihe.net/PCC/PCS/0.1.0/package.tgz), or fetching package list for ihe.pcc.pcs from https://profiles.ihe.net/PCC/PCS/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/PCC/PCS/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-84.log)"
+      }
+    },
+    {
+      "name": "IHE Patient Demographics Query for Mobile (PDQm)",
+      "category": "Administration",
+      "npm-name": "ihe.iti.pdqm",
+      "description": "Defines a lightweight RESTful interface to a patient demographics supplier leveraging technologies readily available to mobile applications and lightweight browser based applications",
+      "authority": "IHE",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://profiles.ihe.net/ITI/PDQm/history.html",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.PDQm/branches/main",
+      "canonical": "https://profiles.ihe.net/ITI/PDQm",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 3,
+        "examples": 4
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "3.2.0",
+          "package": "ihe.iti.pdqm#3.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/PDQm/3.2.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Patient Identifier Cross-referencing for Mobile (PIXm)",
+      "category": "Administration",
+      "npm-name": "ihe.iti.pixm",
+      "description": "Defines a lightweight RESTful interface to a Patient Identifier Cross-reference Manager, leveraging technologies readily available to mobile applications and lightweight browser based applications",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/PIXm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/PIXm",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.PIXm",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 8,
+        "operations": 1,
+        "examples": 17
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "3.1.0",
+          "package": "ihe.iti.pixm#3.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/PIXm/3.1.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Patient Master Identity Registry (PMIR)",
+      "category": "Administration",
+      "npm-name": "ihe.iti.pmir",
+      "description": "Supports the creating, updating and deprecating of patient master identity information about a subject of care, as well as subscribing to these changes, using the HL7 FHIR standard and its RESTful transactions. In PMIR, \u201cpatient identity\u201d information includes all information found in the FHIR Patient Resource such as identifier, name, phone, gender, birth date, address, marital status, photo, others to contact, preference for language, general practitioner, and links to other instances of identities. The \u201cpatient master identity\u201d is a dominant identity managed centrally among many participating organizations (a.k.a., \u201cGolden Patient Identity\u201d).",
+      "authority": "IHE",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "https://profiles.ihe.net/ITI/PMIR/history.html",
+      "analysis": {
+        "error": "Error fetching package directly (https://profiles.ihe.net/ITI/PMIR/0.1.0/package.tgz), or fetching package list for ihe.iti.pmir from https://profiles.ihe.net/ITI/PMIR/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/ITI/PMIR/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-23.log)"
+      },
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.PMIR/branches/master/index.html",
+      "canonical": "https://profiles.ihe.net/ITI/PMIR",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.6.0",
+          "package": "ihe.iti.pmir#1.6.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/PMIR/1.6.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Quality Outcome Reporting for EMS (QORE)",
+      "category": "Medication / Immunization",
+      "npm-name": "ihe.qrph.qore",
+      "description": "Supports transmission of clinical data for use in calculating Emergency Medical Services Quality measures. Focus on Stroke, CPR, and STEMI",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Quality_Outcome_Reporting_for_EMS",
+      "canonical": "http://wiki.ihe.net/index.php/Quality_Outcome_Reporting_for_EMS",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.qrph.qore#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Quality_Outcome_Reporting_for_EMS"
+        }
+      ],
+      "analysis": {
+        "error": "Error fetching package directly (http://profiles.ihe.net/QRPH/QORE/0.1.0/package.tgz), or fetching package list for ihe.qrph.qore from http://profiles.ihe.net/QRPH/QORE/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/QRPH/QORE/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-92.log)"
+      }
+    },
+    {
+      "name": "IHE Query for Existing Data for Mobile (QEDm)",
+      "category": "EHR Access",
+      "npm-name": "ihe.pcc.qedm",
+      "description": "Supports queries for clinical data elements, including observations, allergy and intolerances, conditions, diagnostic results, medications, immunizations, procedures, encounters and provenance by making the information widely available to other systems within and across enterprises",
+      "authority": "IHE",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Query_for_Existing_Data_for_Mobile",
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.qedm#0.2.1"
+      },
+      "canonical": "https://profiles.ihe.net/PCC/QEDm",
+      "ci-build": "http://build.fhir.org/ig/IHE/PCC.QEDm/branches/master/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "3.0.0",
+          "package": "ihe.pcc.qedm#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/PCC/QEDm/3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "IHE Reconciliation of Clinical Content and Care Providers (RECON)",
+      "category": "Administration",
+      "npm-name": "ihe.pcc.recon",
+      "description": "Provides the ability to communicate lists of clinical data that were reconciled, when they were reconciled and who did the reconciliation using CDA\u00ae constructs and FHIR\u00ae Resource attributes",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Reconciliation_of_Clinical_Content_and_Care_Providers",
+      "canonical": "http://wiki.ihe.net/index.php/Reconciliation_of_Clinical_Content_and_Care_Providers",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pcc.recon#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Reconciliation_of_Clinical_Content_and_Care_Providers"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.recon#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Remote Patient Monitoring (RPM)",
+      "category": "Personal Healthcare",
+      "npm-name": "ihe.pcc.rpm",
+      "description": "Provides means of reporting measurements taken by Personal Healthcare Devices in a remote location",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Remote_Patient_Monitoring",
+      "canonical": "http://wiki.ihe.net/index.php/Remote_Patient_Monitoring",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pcc.rpm#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Remote_Patient_Monitoring"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.rpm#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Routine Interfacility Patient Transport (RIPT)",
+      "category": "Communications",
+      "npm-name": "ihe.pcc.ript",
+      "description": "Provides means of updating a Transport team with critical and necessary medical information on a patient to be transported",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Routine_Interfacility_Patient_Transport",
+      "canonical": "http://wiki.ihe.net/index.php/Routine_Interfacility_Patient_Transport",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pcc.ript#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Routine_Interfacility_Patient_Transport"
+        }
+      ],
+      "analysis": {
+        "error": "Error fetching package directly (http://profiles.ihe.net/PCC/RIPT/0.1.0/package.tgz), or fetching package list for ihe.pcc.ript from http://profiles.ihe.net/PCC/RIPT/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/PCC/RIPT/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-73.log)"
+      }
+    },
+    {
+      "name": "IHE SDC/eCC on FHIR",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.ihe-sdc-ecc",
+      "description": "Integrating the Healthcare Enterprise (IHE) Structured Data Capture (SDC) on FHIR uses a form-driven workflow to capture and transmit encoded data by creating FHIR Observations. The primary use case for this is transmitting data captured in College of American Pathologists electronic Cancer Checklists (eCCs), which are distributed as IHE SDC templates.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ihe-sdc-ecc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ihe-sdc-ecc",
+      "ci-build": "http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.ihe-sdc-ecc#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/ihe-sdc-ecc/STU1"
+        }
+      ]
+    },
+    {
+      "name": "IHE Standardized Operational Log of Events (SOLE)",
+      "category": "Administration",
+      "npm-name": "ihe.rad.sole",
+      "description": "Defines a way to exchange information about events that can then be collected and displayed using standard methods",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Standardized_Operational_Log_of_Events",
+      "canonical": "http://wiki.ihe.net/index.php/Standardized_Operational_Log_of_Events",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.rad.sole#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Standardized_Operational_Log_of_Events"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.rad.sole#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Uniform Barcode Processing (UBP)",
+      "category": "Medications / Immunizations",
+      "npm-name": "ihe.pharm.ubp",
+      "description": "Uniform Barcode Processing for Medications",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Uniform_Barcode_Processing",
+      "canonical": "http://wiki.ihe.net/index.php/Uniform_Barcode_Processing",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pharm.ubp#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Uniform_Barcode_Processing"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pharm.ubp#0.1.0"
+      }
+    },
+    {
+      "name": "IHE Vital Records Death Reporting (VRDR)",
+      "category": "Medication / Immunization",
+      "npm-name": "ihe.qrph.vrdr",
+      "description": "Defines a Retrieve Form for Data Capture (RFD) content profile that will specify derivation of source content from a medical summary document. by defining requirements for form filler content and form manager handling of the content",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Vital_Records_Death_Reporting",
+      "canonical": "http://wiki.ihe.net/index.php/Vital_Records_Death_Reporting",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.qrph.vrdr#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Vital_Records_Death_Reporting"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.qrph.vrdr#0.1.0"
+      }
+    },
+    {
+      "name": "Immunization Decision Support Forecast FHIR IG",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.immds",
+      "description": "A common FHIR implementation guide that expert systems may use to provide a common consistent interface enable decisioin support recommending which vaccinations a patient is due for next",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/immds/history.html",
+      "canonical": "http://hl7.org/fhir/us/immds",
+      "ci-build": "http://build.fhir.org/ig/HL7/ImmunizationFHIRDS",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 4,
+        "operations": 1,
+        "valuesets": 4,
+        "codeSystems": 3,
+        "examples": 6
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.immds#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/immds/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Immunization Decision Support Forecast FHIR IG",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.uv.immds",
+      "description": "The scope of this project is to produce and ballot a Standard for Trial Use (STU) Fast Healthcare Interoperability Resources (FHIR) implementation guide (IG) for use in Immunization Decision Support Forecast.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/immds/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/immds",
+      "ci-build": "http://build.fhir.org/ig/HL7/ImmunizationFHIRDS",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 3,
+        "operations": 1
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.uv.immds#0.2.0",
+          "fhir-version": [
+            "4.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/immds/2019Sep"
+        }
+      ]
+    },
+    {
+      "name": "Integrated Reporting Applications",
+      "category": "Imaging",
+      "npm-name": "ihe.rad.ira",
+      "description": "The Integrated Reporting Applications (IRA) profile helps applications that are used together during reporting (e.g., image display, report creator, clinical applications, AI tools, etc) to share information using a standard called FHIRcast. Each application can share what it is doing and the data it is creating, referred to as Context and Content, respectively. Other applications are notified so they can then intelligently synchronize their behavior or use the new data.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/RAD/IRA/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/RAD/IRA",
+      "ci-build": "http://build.fhir.org/ig/IHE/RAD.IRA/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.rad.ira#1.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://profiles.ihe.net/RAD/IRA/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "International Birth And Child Model Implementation Guide",
+      "category": "Clinical Observations",
+      "npm-name": "hl7.fhir.uv.ibcm",
+      "description": "During a pregnancy clinical systems communicate data about the mother, the unborn fetus(es), the pregnancy, and child(ren). This includes information shared among EHR, ultrasound, radiology, lab and pharmacy systems. This IG explains how you model and communicate data and relate the fetus(es) to the mother using the FHIR resource Patient with extension indicating a distinct fetal record. Options for referencing information such as observation about the fetus as a body site within the maternal record will also be included. Examples and diagrams are provided to illustrate the use cases.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ibcm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ibcm",
+      "ci-build": "http://build.fhir.org/ig/HL7/fetal_records",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot2",
+          "package": "hl7.fhir.uv.ibcm#1.0.0-ballot2",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/ibcm/2024Sep"
+        }
+      ]
+    },
+    {
+      "name": "International Patient Access",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.uv.ipa",
+      "description": "International Patient Access (IPA) defines a minimal, base set of FHIR profiles specifically intended to be used as-is, or built on top of by countries looking to enable patient access and patient-facing apps accessing data via FHIR",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/ipa/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/ipa",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-ipa",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 11,
+        "operations": 1,
+        "examples": 13
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.uv.ipa#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/ipa/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.ipa#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/ipa/STU1"
+        }
+      ]
+    },
+    {
+      "name": "International Patient Summary",
+      "category": "Patient Summary",
+      "npm-name": "hl7.fhir.uv.ips",
+      "description": "The International Patient Summary (IPS) is a minimal and non-exhaustive patient summary, specialty-agnostic, condition-independent, but readily usable by clinicians for the cross-border unscheduled care of a patient",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/ips/history.html",
+      "canonical": "http://hl7.org/fhir/uv/ips",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-ips",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "profiles": 33,
+        "extensions": 1,
+        "valuesets": 44,
+        "codeSystems": 1,
+        "examples": 33
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.uv.ips#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/ips/STU2"
+        }
+      ]
+    },
+    {
+      "name": "Interoperable Digital Identity and Patient Matching",
+      "category": "Privacy / Security",
+      "npm-name": "hl7.fhir.us.identity-matching",
+      "description": "This FHIR implementation Guide provides guidance on leveraging Patient Matching and Digital Identity capabilities together to improve match quality and overall identity assurance in FHIR transactions. It defines methods to inform and execute cross organizational and internal patient matches via FHIR when requested for a permitted purpose or authorized by the Patient directly or by the Patient\u2019s delegate. ",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/identity-matching/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/identity-matching",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-identity-matching-ig",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 3,
+        "valuesets": 1,
+        "codeSystems": 1,
+        "examples": 3
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.identity-matching#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/identity-matching/2024SEP"
+        },
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.identity-matching#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/identity-matching/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Japanese Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.jp.core",
+      "description": "A core set of FHIR resources profiled for the Japanese context",
+      "authority": "HL7 Japan (JAMI)",
+      "product": [
+        "fhir"
+      ],
+      "country": "jp",
+      "language": [
+        "ja"
+      ],
+      "history": "https://jpfhir.jp/fhir/core/history.html",
+      "canonical": "http://jpfhir.jp/fhir/core",
+      "editions": [
+        {
+          "name": "Release",
+          "ig-version": "1.2.0",
+          "package": "jpfhir.jp.core#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://jpfhir.jp/fhir/core/1.2.0"
+        },
+        {
+          "name": "Release",
+          "ig-version": "1.1.2",
+          "package": "jpfhir.jp.core#1.1.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://jpfhir.jp/fhir/core/1.1.2"
+        }
+      ]
+    },
+    {
+      "name": "KLChildren",
+      "category": "Clinical Registries",
+      "npm-name": "kl.dk.fhir.children",
+      "description": "This implementation guide describes the delivery of children health data to KL Gateway.",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/children/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/children",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-children",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "2.1.0",
+          "package": "kl.dk.fhir.children#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/children/2.1.0"
+        }
+      ]
+    },
+    {
+      "name": "KLCore",
+      "category": "Frameworks",
+      "npm-name": "kl.dk.fhir.core",
+      "description": "Base Profiles for KL",
+      "authority": "Kommunernes Landsforening (DK)",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/core/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/core",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/KL-dk",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.2.0",
+          "package": "kl.dk.fhir.core#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/core/1.2.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "KLFFBMessaging",
+      "category": "Frameworks",
+      "npm-name": "kl.dk.fhir.ffbmessaging",
+      "description": "Danish municipalities implementation guide for FFB messaging. A standard for exchanging social information from citizen journals between municipalities. The aim is to support citizens continuously, e.g. when they move, or receives interventions outside their home municipality.",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/ffbmessaging/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/ffbmessaging",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-ffb-messaging",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "kl.dk.fhir.ffbmessaging#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/ffbmessaging/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "KLFFBReporting",
+      "category": "Clinical Registries",
+      "npm-name": "kl.dk.fhir.ffbreporting",
+      "description": "Danish municipalities implementation guide for FFB reporting. A standard for reporting social information from citizen journals to a gateway. The aim is to use the data in population based studies and management information systems",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/ffbreporting/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/ffbreporting",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-ffb-reporting",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "kl.dk.fhir.ffbreporting#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/ffbreporting/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "KLFFinst",
+      "category": "Frameworks",
+      "npm-name": "kl.dk.fhir.ffinst",
+      "description": "Danish municipalities implementation guide for FFInst ",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/ffinst/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/ffinst",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/KL-dk-tools",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "kl.dk.fhir.ffinst#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/ffinst/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "KLGateway",
+      "category": "Clinical Registries",
+      "npm-name": "kl.dk.fhir.gateway",
+      "description": "KL Submission Guide of data for reporting of various elements",
+      "authority": "Kommunernes Landsforening (DK)",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/gateway/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/gateway",
+      "product": [
+        "fhir"
+      ],
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-gateway/branches/main",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.2.0",
+          "package": "kl.dk.fhir.gateway#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/gateway/1.2.0"
+        }
+      ]
+    },
+    {
+      "name": "KLGatewayPrevention",
+      "category": "Clinical Registries",
+      "npm-name": "kl.dk.fhir.prevention",
+      "description": "This implementation guide describes the delivery of \u00a7119 prevention/health promotion data to KL Gateway.",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/prevention/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/prevention",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-gateway-prevention",
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "2.0.0",
+          "package": "kl.dk.fhir.prevention#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/prevention/2.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "KLGatewayRehab",
+      "category": "Clinical Registries",
+      "npm-name": "kl.dk.fhir.rehab",
+      "description": "This implementation guide describes the delivery of \u00a7140 rehabilitation data to KL Gateway.",
+      "authority": "HL7 Denmark",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/rehab/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/rehab",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-gateway-rehab",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "2.2.0",
+          "package": "kl.dk.fhir.rehab#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/rehab/2.2.0"
+        }
+      ]
+    },
+    {
+      "name": "KLTerm",
+      "category": "Terminology",
+      "npm-name": "kl.dk.fhir.term",
+      "description": "Base Terminology for KL",
+      "authority": "Kommunernes Landsforening (DK)",
+      "country": "dk",
+      "history": "http://fhir.kl.dk/term/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.kl.dk/term",
+      "ci-build": "http://build.fhir.org/ig/hl7dk/kl-term",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "2.3.0",
+          "package": "kl.dk.fhir.term#2.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.kl.dk/term/2.3.0"
+        }
+      ]
+    },
+    {
+      "name": "KR Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.kr.core",
+      "description": "Base Korean national implementation guide",
+      "authority": "HL7 Korea",
+      "product": [
+        "fhir"
+      ],
+      "country": "kr",
+      "language": [
+        "ko"
+      ],
+      "history": "http://www.hl7korea.or.kr/fhir/krcore/history.html",
+      "ci-build": "https://build.fhir.org/ig/hl7korea/krcore",
+      "canonical": "http://www.hl7korea.or.kr/fhir/krcore",
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.2",
+          "package": "hl7.fhir.kr.core#1.0.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://www.hl7korea.or.kr/fhir/krcore/STU1.0.2"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.kr.core#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://www.hl7korea.or.kr/fhir/krcore/STU2"
+        }
+      ]
+    },
+    {
+      "name": "Logica COVID-19 FHIR Profile Library IG",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.covid19library",
+      "description": "Support for exchanges of COVD-19 Patient Specific Data.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/covid19library/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/covid19library",
+      "ci-build": "http://build.fhir.org/ig/HL7/covid19library",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 146,
+        "extensions": 4,
+        "valuesets": 43,
+        "codeSystems": 2,
+        "examples": 141
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Informative Informative",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.covid19library#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/covid19library/informative1"
+        }
+      ]
+    },
+    {
+      "name": "Loinc/IVD Test mapping",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.livd",
+      "description": "The LIVD Implementation Guide provides a industry standard expression for an IVD device manufacturer's suggestions for a specific device's mapping from the internal, proprietary IVD test codes to suggested LOINC codes when a LIS manager is connecting and configuring a device to the LIS",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/livd/history.html",
+      "canonical": "http://hl7.org/fhir/uv/livd",
+      "ci-build": "http://build.fhir.org/ig/HL7/livd",
+      "analysis": {
+        "content": true,
+        "diagnostics": true,
+        "profiles": 10,
+        "extensions": 4,
+        "valuesets": 6,
+        "codeSystems": 5,
+        "examples": 8
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.livd#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/livd/2024Jan"
+        }
+      ]
+    },
+    {
+      "name": "Making EHR Data MOre available for Research and Public Health (MedMorph)",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.medmorph",
+      "description": "Making EHR Data More Available for Research and Public Health (MedMorph) Reference Architecture enables clinical data exchange between EHR systems, public health systems/authorities, data repositories, and research organizations.  This data exchange utilizes if applicable, knowledge repositories and backend services applications (e.g. FHIR APIs) to determine the triggering event(s) for the data exchange, the process for the data exchange, and validation that the data being exchanged meets a set of rules in order to expedite the data exchange. ",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/medmorph/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/medmorph",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-medmorph",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 13,
+        "extensions": 9,
+        "operations": 4,
+        "valuesets": 4,
+        "codeSystems": 5,
+        "examples": 18
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Release 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.medmorph#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/medmorph/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Making EHR Data MOre available for Research and Public Health (MedMorph) Central Cancer Registry Reporting Content IG",
+      "category": "Public Health and Research",
+      "npm-name": "hl7.fhir.us.central-cancer-registry-reporting",
+      "description": "This guide defines how healthcare organizations onboard a new research data partner. It provides guidance to extract data from EHRs, transform the data, and populate data marts",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/central-cancer-registry-reporting/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/central-cancer-registry-reporting",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-central-cancer-registry-reporting",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 6,
+        "extensions": 1,
+        "valuesets": 1,
+        "examples": 10
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.central-cancer-registry-reporting#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/central-cancer-registry-reporting/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "Making EHR Data MOre available for Research and Public Health (MedMorph) Healthcare Surveys Reporting Content IG",
+      "category": "Public Health and Research",
+      "npm-name": "hl7.fhir.us.health-care-surveys-reporting",
+      "description": "This guide focuses on the National Hospital Care Survey (NHCS) and National Ambulatory Medical Care Survey (NAMCS) data that will be extracted from EHRs and/or clinical data repositories via FHIR and APIs and sent to a system hosted at the federal level.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/health-care-surveys-reporting/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/health-care-surveys-reporting",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "medsMgmt": true,
+        "profiles": 4,
+        "examples": 13
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-health-care-surveys-reporting-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.health-care-surveys-reporting#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/health-care-surveys-reporting/STU2"
+        }
+      ]
+    },
+    {
+      "name": "Making EHR Data MOre available for Research and Public Health (MedMorph) Research Content IG",
+      "category": "Public Health and Research",
+      "npm-name": "hl7.fhir.us.medmorph-research-dex",
+      "description": "This guide focuses on the National Hospital Care Survey (NHCS) and National Ambulatory Medical Care Survey (NAMCS) data that will be extracted from EHRs and/or clinical data repositories via FHIR and APIs and sent to a system hosted at the federal level.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/medmorph-research-dex/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/medmorph-research-dex",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-medmorph-research-dex",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "carePlanning": true,
+        "profiles": 1,
+        "examples": 6
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.us.medmorph-research-dex#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/medmorph-research-dex/2022Jan"
+        }
+      ]
+    },
+    {
+      "name": "Making Ehr Data MOre Available to Research and Public Health (MedMorph)",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.fhir-medmorph",
+      "description": "The The MedMorph FHIR IG enables Public Health and Research Organizations to access EHR data without increasing provider burden.",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/fhir-medmorph/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/fhir-medmorph",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-medmorph",
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.us.fhir-medmorph#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/fhir-medmorph/2021Jan"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id hl7.fhir.us.fhir-medmorph#0.1.0"
+      }
+    },
+    {
+      "name": "Maternal and Infant Health Research",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.mihr",
+      "description": "This guide focuses on calculation of maternal-related cohorts from available maternal care information sources. It specifies how to calculate two maternal-related cohort measures and link to maternal longitudinal record with associated child record(s). Initial use cases focus on pregnancy and subsequent death within a specific time frame and hypertensive disorders of pregnancy pre, ante, and postpartum. The IG leverages MedMorph, SANER, US Core profiles, and broader public health IGs",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/mihr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/mihr",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-mmm-ig",
+      "analysis": {
+        "valuesets": 9,
+        "examples": 24
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.mihr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mihr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "MCC eCare Plan Implementation Guide",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.mcc",
+      "description": "Provides representation of clinical and social data elements in the FHIR Care Plan format. Focuses on 4 common chronic conditions: 1) chronic kidney disease (CKD), 2) type 2 diabetes mellitus (T2DM), 3) cardiovascular diseases (specifically, hypertension, ischemic heart disease and heart failure), and 4) pain.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/mcc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/mcc",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-us-mcc",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.mcc#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mcc/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Medication IG DE",
+      "category": "National Base",
+      "npm-name": "de.fhir.medication",
+      "description": "Developed for the German healthcare context, this specification provides a set of profiles and extensions for medication management, currently focused on Dosage and Timing, based on FHIR R4.",
+      "authority": "HL7 Deutschland e.V.",
+      "country": "de",
+      "history": "http://ig.fhir.de/igs/medication/history.html",
+      "language": [
+        "de"
+      ],
+      "canonical": "http://ig.fhir.de/igs/medication",
+      "ci-build": "http://build.fhir.org/ig/hl7germany/medication-ig-de-r4",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "de.fhir.medication#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://ig.fhir.de/igs/medication/1.0.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "Medication Prescription and Dispense (MPD)",
+      "category": "Medication",
+      "npm-name": "ihe.pharm.mpd",
+      "description": "The Medication Prescription and Dispense (MPD) profile defines profiles and actors for interoperable systems handling medication ordering and dispensing.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/PHARM/MPD/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/PHARM/MPD",
+      "ci-build": "http://build.fhir.org/ig/IHE/pharm-mpd/branches/master/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0-comment-2",
+          "package": "ihe.pharm.mpd#1.0.0-comment-2",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://profiles.ihe.net/PHARM/MPD/1.0.0-comment-2"
+        }
+      ]
+    },
+    {
+      "name": "Medicolegal Death Investigation (MDI)",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.mdi",
+      "description": "This US-specific IG supports exchange of data for medicolegal death investigations, for example from a toxicology lab to a case management system (upstream), and from a case management system to a  jurisdictional electronic death registration system (EDRS)(downstream).",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/mdi/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/mdi",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-mdi-ig",
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "clinicalCore": true,
+        "diagnostics": true,
+        "profiles": 16,
+        "extensions": 2,
+        "valuesets": 7,
+        "codeSystems": 2,
+        "examples": 40
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.mdi#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mdi/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.mdi#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mdi/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.mdi#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mdi/STU1"
+        }
+      ]
+    },
+    {
+      "name": "mednet Implementation Guide",
+      "category": "Patient Summary",
+      "npm-name": "swiss.mednet.fhir",
+      "description": "The mednet.swiss implementation guide describes the FHIR profiles used to interface with the mednet software",
+      "authority": "novcom AG (CH)",
+      "product": [
+        "fhir"
+      ],
+      "country": "ch",
+      "history": "https://mednet.swiss/fhir/history.html",
+      "canonical": "https://mednet.swiss/fhir",
+      "analysis": {},
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Minimal Common Oncology Data Elements (mCODE)",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.mcode",
+      "description": "This IG specifies a core set of common data elements for cancer that is clinically applicable in every electronic patient record with a cancer diagnosis. It is intended to enable standardized information exchange among EHRs/oncology information systems and reuse of data by other stakeholders (e.g. quality measurement, research).",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/mcode/history.html",
+      "canonical": "http://hl7.org/fhir/us/mcode",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-mCODE-ig",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "profiles": 28,
+        "extensions": 14,
+        "operations": 1,
+        "valuesets": 96,
+        "codeSystems": 2,
+        "examples": 97
+      },
+      "language": [
+        "en"
+      ],
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU4",
+          "ig-version": "4.0.0",
+          "package": "hl7.fhir.us.mcode#4.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mcode/STU4"
+        },
+        {
+          "name": "STU 3",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.us.mcode#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mcode/STU3"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.mcode#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mcode/STU2.1"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.mcode#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mcode/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.mcode#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/mcode/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Mobile Antepartum Summary",
+      "category": "Clinical Observations",
+      "npm-name": "ihe.pcc.maps",
+      "description": "Antepartum Summary is a content profile that defines the structure for the aggregation of significant events, diagnoses, and plans of care derived from the visits over the course of an antepartum episode.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/PCC/mAPS/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/PCC/mAPS",
+      "ci-build": "http://build.fhir.org/ig/IHE/PCC.mAPS/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication Ballot",
+          "ig-version": "1.0.0-comment",
+          "package": "ihe.pcc.maps#1.0.0-comment",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/PCC/mAPS/1.0.0-comment"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Mobile Antepartum Summary US Realm",
+      "category": "Clinical Observations",
+      "npm-name": "ihe.pcc.maps.us",
+      "description": "Antepartum Summary is a content profile that defines the structure for the aggregation of significant events, diagnoses, and plans of care derived from the visits over the course of an antepartum episode.",
+      "authority": "IHE",
+      "country": "us",
+      "history": "https://profiles.ihe.net/us/PCC/mAPS/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/us/PCC/mAPS",
+      "ci-build": "http://build.fhir.org/ig/IHE/PCC.mAPS.us/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication Ballot",
+          "ig-version": "1.0.0-comment",
+          "package": "ihe.pcc.maps.us#1.0.0-comment",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/us/PCC/mAPS/1.0.0-comment"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "MyHealth@Eu Laboratory Report",
+      "category": "Laboratory Report",
+      "npm-name": "myhealth.eu.fhir.laboratory",
+      "description": "MyHealth@EU Laboratory Report Implementaion Guide for European Cross border services.",
+      "authority": "eHMSEG STF Architecture WG",
+      "country": "eu",
+      "history": "http://fhir.ehdsi.eu/laboratory/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ehdsi.eu/laboratory",
+      "ci-build": "https://build-fhir.ehdsi.eu/laboratory",
+      "editions": [
+        {
+          "name": "MyHealth@EU wave 8 trial use release",
+          "ig-version": "0.1.1",
+          "package": "myhealth.eu.fhir.laboratory#0.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ehdsi.eu/laboratory/0.1.1"
+        }
+      ]
+    },
+    {
+      "name": "M\u00e9dicosocial - Transfert de donn\u00e9es DUI",
+      "category": "Clinical Documents",
+      "npm-name": "ans.fhir.fr.tddui",
+      "description": "Clinical Documents",
+      "authority": "ANS (FR)",
+      "country": "fr",
+      "history": "https://interop.esante.gouv.fr/ig/fhir/tddui/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://interop.esante.gouv.fr/ig/fhir/tddui",
+      "ci-build": "https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/ig/main",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "public-comment",
+          "ig-version": "2.2.0-ballot",
+          "package": "ans.fhir.fr.tddui#2.2.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://interop.esante.gouv.fr/ig/fhir/tddui/2.2.0-ballot"
+        }
+      ]
+    },
+    {
+      "name": "National Directory of Healthcare Providers and Services (NDH) Implementation Guide",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.us.ndh",
+      "description": "Standard for the population, verification and exchange of Health and Social Care Directory information between a Validated National Directory and local directories (primarily for workflow integration).  This applies to individual demographics, organizational demographics, relationship between individuals and organizations, services provided, and electronic endpoint metadata",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/ndh/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/ndh",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-us-ndh",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.ndh#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ndh/STU1"
+        }
+      ]
+    },
+    {
+      "name": "National Healthcare Directory Attestation",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.us.directory-attestation",
+      "description": "Provides the methods and standards for the contribution, attestation, and validation of information in the National Directory.  This applies to individual demographics, organizational demographics, relationship between individuals and organizations, services provided, and electronic endpoint metadata.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/directory-attestation/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/directory-attestation",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-directory-attestation",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.directory-attestation#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/directory-attestation/2022Sep"
+        }
+      ]
+    },
+    {
+      "name": "National Healthcare Directory Exchange",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.us.directory-exchange",
+      "description": "Standard for exchange of Health and Social Care Directory information between a Validated National Directory and a federated directory (primarily for workflow integration).",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/directory-exchange/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/directory-exchange",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-directory-exchange",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.directory-exchange#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/directory-exchange/2022Sep"
+        }
+      ]
+    },
+    {
+      "name": "National Healthcare Query",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.us.directory-query",
+      "description": "Standard for endpoint query request and response for Validated National Directory federated access directories",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/directory-query/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/directory-query",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-directory-query",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.directory-query#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/directory-query/2022Sep"
+        }
+      ]
+    },
+    {
+      "name": "National Healthcare Safety Network (NHSN) Digital Quality Measure (dQM) Reporting Implementation Guide",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.nhsn-dqm",
+      "description": "This implementation guide creates a framework for reporting to the National Healthcare Safety Network (NHSN) using digital quality measures (dQMs). NHSN will create FHIR Measure resources that comply with this framework and receive the resulting MeasureReport and related resources. The Measure resources will be processed by a measure evaluation engine, which can either pull data from an EHR FHIR API for evaluation, or be implemented inside an EHR directly.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/nhsn-dqm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/nhsn-dqm",
+      "ci-build": "http://build.fhir.org/ig/HL7/nhsn-dqm",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.nhsn-dqm#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/nhsn-dqm/STU1"
+        }
+      ]
+    },
+    {
+      "name": "NHSN Reporting of Adverse Drug Events - Hypoglycemia",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.nhsn-ade",
+      "description": "US Realm IG providing guidance to implementers on reporting data elements to CDC's National Healthcare Safety Network (NHSN) related to inpatient blood glucose laboratory (including point-of-care) results and medication administration data (medications received during inpatient stay) based on FHIR resources. This IG addresses how inpatient EHR systems should format patient, blood glucose, and medication information to enable hospital reporting of these data to NHSN.  Query parameters are defined for each type of data element based on FHIR resources.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/nhsn-ade/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/nhsn-ade",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-nhsn-ade-ig/branches/main/index.html",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 3,
+        "examples": 17
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 on FHIR R4",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.nhsn-ade#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/nhsn-ade/STU1"
+        }
+      ]
+    },
+    {
+      "name": "NHSN Reporting: Inpatient Medication Administration",
+      "category": "Surveillience / Reporting",
+      "npm-name": "hl7.fhir.us.nhsn-med-admin",
+      "description": "US Realm IG providing guidance to implementers on reporting data elements to CDC's National Healthcare Safety Network (NHSN) related to inpatient medication administration for hospitalized patients diagnosed with COVID-19, based on FHIR resources and as part of NHSN COVID-19 reporting pathways.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/nhsn-med-admin/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/nhsn-med-admin",
+      "ci-build": "http://build.fhir.org/ig/HL7/nhsn-med-admin-ig/branches/main/index.html",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 5,
+        "examples": 15
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 on FHIR R4",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.nhsn-med-admin#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/nhsn-med-admin/STU1"
+        }
+      ]
+    },
+    {
+      "name": "NIHDI Terminology Profiles for Belgium",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.be.nihdi-terminology",
+      "description": "NIHDI Terminology Profiles for Belgium",
+      "authority": "eHealth Platform (BE)",
+      "country": "be",
+      "history": "https://www.ehealth.fgov.be/standards/fhir/nihdi-terminology/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://www.ehealth.fgov.be/standards/fhir/nihdi-terminology",
+      "ci-build": "http://build.fhir.org/ig/hl7-be/nihdi-terminology",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Trial Use",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.be.nihdi-terminology#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://www.ehealth.fgov.be/standards/fhir/nihdi-terminology/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "NZ Base",
+      "category": "National Base",
+      "npm-name": "fhir.org.nz.ig.base",
+      "description": "Base New Zealand national implementation guide",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "nz",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.org.nz/ig/base",
+      "history": "https://fhir.org.nz/ig/base/package-list.json",
+      "ci-build": "http://build.fhir.org/ig/HL7NZ/nzbase/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Release 3",
+          "ig-version": "3.0.0",
+          "package": "fhir.org.nz.ig.base#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.org.nz/ig/base"
+        }
+      ],
+      "analysis": {
+        "error": "Error fetching package directly (http://fhir.org.nz/ig/base/1.0.0/package.tgz), or fetching package list for fhir.org.nz.ig.base from http://fhir.org.nz/ig/base/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://fhir.org.nz/ig/base/1.0.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-6.log)"
+      }
+    },
+    {
+      "name": "Observations of notifiable communicable infectious diseases",
+      "category": "Medication / Immunization",
+      "npm-name": "ch.fhir.ig.ch-elm",
+      "description": "CH ELM is a project of the Swiss Federal Office of Public Health (FOPH), Communicable Diseases Division, to enable laboratories to send their observations of notifiable communicable infectious diseases to the FOPH electronically.",
+      "authority": "FOPH",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-elm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.ch/ig/ch-elm",
+      "ci-build": "http://build.fhir.org/ig/ahdis/ch-elm/index.html",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.7.0",
+          "package": "ch.fhir.ig.ch-elm#1.7.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-elm/1.7.0"
+        }
+      ]
+    },
+    {
+      "name": "Occupational Data for Health",
+      "category": "Clinical Observations",
+      "npm-name": "hl7.fhir.us.odh",
+      "description": "This IG covers the specific data that covers past or present jobs, usual work, employment status, retirement date and combat zone period for the subject. It also includes the past or present jobs and usual work of other household members",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/odh/history.html",
+      "canonical": "http://hl7.org/fhir/us/odh",
+      "ci-build": "http://build.fhir.org/ig/HL7/us-odh",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 6,
+        "extensions": 2,
+        "valuesets": 9,
+        "codeSystems": 1,
+        "examples": 8
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.3 on FHIR R4",
+          "ig-version": "1.3.0",
+          "package": "hl7.fhir.us.odh#1.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/odh/STU1.3"
+        },
+        {
+          "name": "STU 1.2 on FHIR R4",
+          "ig-version": "1.2.0",
+          "package": "hl7.fhir.us.odh#1.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/odh/STU1.2"
+        },
+        {
+          "name": "STU 1.1 on FHIR R4",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.odh#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/odh/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.odh#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/odh/STU1"
+        }
+      ]
+    },
+    {
+      "name": "ONCOFAIR FHIR Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "ltsi.fhir.oncofair",
+      "description": "The OncoFAIR project is designed to improve the interoperability and reuse of healthcare data in oncology, focusing on chemotherapy.",
+      "authority": "KEREVAL, LTSI",
+      "country": "fr",
+      "history": "http://oncofair-ig.kereval.cloud/ltsi.fhir.oncofair/history.html",
+      "language": [
+        "en"
+      ],
+      "ci-build": "https://oncofair.github.io/FHIR-ImplementationGuide-Article/main/ig",
+      "canonical": "http://oncofair-ig.kereval.cloud",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "final-text",
+          "ig-version": "0.1.0",
+          "package": "ltsi.fhir.oncofair#0.1.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://oncofair-ig.kereval.cloud/ltsi.fhir.oncofair"
+        }
+      ]
+    },
+    {
+      "name": "Order & Referral by Form (CH-ORF)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-orf",
+      "description": "The Order & Referral by Form (CH-ORF) Profile describes how forms for eReferrals, requests for information (such as diagnostic imaging results, lab results, discharge reports etc.) can be defined, deployed and used in order to achieve a syntactical and semantically consistent cross enterprise information exchange.",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-orf/history.html",
+      "canonical": "http://fhir.ch/ig/ch-orf",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-orf",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 3",
+          "ig-version": "3.0.0",
+          "package": "ch.fhir.ig.ch-orf#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-orf/3.0.0"
+        }
+      ],
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Order Catalog Implementation Guide",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.uv.order-catalog",
+      "description": "An Order Catalog is an administered homogeneous collection of items such as medication products, laboratory tests, procedures, medical devices or knowledge artifacts such as order sets, which support the ordering process, or more generally the healthcare process.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/order-catalog/history.html",
+      "canonical": "http://hl7.org/fhir/uv/order-catalog",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-order-catalog",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "carePlanning": true,
+        "financials": true,
+        "diagnostics": true,
+        "profiles": 11,
+        "extensions": 8,
+        "valuesets": 4,
+        "codeSystems": 3,
+        "examples": 60
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.uv.order-catalog#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/order-catalog/2020Sep"
+        }
+      ]
+    },
+    {
+      "name": "PACIO Advance Directive Information Implementation Guide",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.fhir.us.pacio-adi",
+      "description": "The Advance Directive Interoperability (ADI) with FHIR implementation guide (IG) describes how to represent, exchange, and verify an individual's advance directive information regarding potential future care and treatment in the event the individual is not able to communicate such information directly.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pacio-adi/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pacio-adi",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "profiles": 15,
+        "extensions": 13,
+        "valuesets": 17,
+        "codeSystems": 2,
+        "examples": 65
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-pacio-adi",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.pacio-adi#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pacio-adi/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "PACIO Cognitive Status Implementation Guide",
+      "category": "Patient Summary",
+      "npm-name": "hl7.fhir.us.pacio-cs",
+      "description": "FHIR R4 IG that leverages eLTSS and utilizes the Confusion Assessment Method (CAM) assessment to enable the sharing of cognitive status information when a patient moves from one clinical care setting to another.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pacio-cs/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pacio-cs",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-pacio-cognitive-status",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 4,
+        "extensions": 3,
+        "valuesets": 1,
+        "codeSystems": 1,
+        "examples": 68
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.pacio-cs#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pacio-cs/STU1"
+        }
+      ]
+    },
+    {
+      "name": "PACIO Functional Status Implementation Guide",
+      "category": "Patient Summary",
+      "npm-name": "hl7.fhir.us.pacio-fs",
+      "description": "FHIR R4 IG that leverages eLTSS and utilizes the Self-Care, Mobility and Prior Device use sections of CMS assessment forms (IRF-PAI, MDS, OASIS, LTCH) to enable the sharing of functional status information when a patient moves from one clinical care setting to another.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pacio-fs/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pacio-fs",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-pacio-functional-status",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 4,
+        "extensions": 3,
+        "valuesets": 1,
+        "codeSystems": 1,
+        "examples": 84
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.pacio-fs#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pacio-fs/STU1"
+        }
+      ]
+    },
+    {
+      "name": "PACIO Personal Functioning and Engagement Implementation Guide",
+      "category": "Patient Summary",
+      "npm-name": "hl7.fhir.us.pacio-pfe",
+      "description": "The Personal Functioning and Engagement IG provides a framework for communicating the functioning of an individual, including their body functions and structure and their activities and participation in society, as well as related clinical care. The IG draws on the health and health-related domains defined within the International Classification of Functioning, Disability and Health (commonly known as ICF).",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pacio-pfe/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pacio-pfe",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-pacio-pfe",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.pacio-pfe#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pacio-pfe/STU2"
+        }
+      ]
+    },
+    {
+      "name": "PACIO Re-Assessment Timepoints Implementation Guide",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.fhir.us.pacio-rt",
+      "description": "The Re-assessment Timepoints FHIR implementation guide (IG) describes how to create definitions for sub-periods of time within an extended post-acute care (PAC) admission and encounter. ",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pacio-rt/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pacio-rt",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-pacio-rt",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 1,
+        "extensions": 1,
+        "valuesets": 4,
+        "codeSystems": 3,
+        "examples": 241
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.pacio-rt#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pacio-rt/STU1"
+        }
+      ]
+    },
+    {
+      "name": "PACIO Transitions of Care Implementation Guide",
+      "category": "Clinical Documents",
+      "npm-name": "hl7.fhir.us.pacio-toc",
+      "description": "Transitions of Care Implementation Guide",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pacio-toc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pacio-toc",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-transitions-of-care-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.pacio-toc#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pacio-toc/2025May"
+        }
+      ]
+    },
+    {
+      "name": "Pan-Canadian Patient Summary",
+      "category": "Patient Summary",
+      "npm-name": "ca.infoway.io.psca",
+      "description": "The Pan-Canadian Patient Summary (PS-CA) IG and accompanying [PS-CA specification](https://infoscribe.infoway-inforoute.ca/pages/viewpage.action?pageId=149160290) adapt the HL7 [International Patient Summary](http://hl7.org/fhir/uv/ips/) (IPS) for use in a Canadian context.",
+      "authority": "Canada Health Infoway",
+      "product": [
+        "fhir"
+      ],
+      "country": "ca",
+      "history": "https://simplifier.net/PS-CA-R1/~guides",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.infoway-inforoute.ca/io/psca",
+      "ci-build": "https://simplifier.net/PS-CA-R1",
+      "editions": [
+        {
+          "name": "Trial Implementation",
+          "ig-version": "1.0.0",
+          "package": "ca.infoway.io.psca#1.0.0-pre",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://packages.simplifier.net/ca.infoway.io.psca/1.0.0-pre"
+        },
+        {
+          "name": "Public Comment 0.3",
+          "ig-version": "0.3.0",
+          "package": "ca.infoway.io.psca#0.3.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://packages.simplifier.net/ca.infoway.io.psca/0.3.2"
+        },
+        {
+          "name": "Public Comment 0.2",
+          "ig-version": "0.0.4",
+          "package": "ca.infoway.io.psca#0.0.4",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://packages.simplifier.net/ca.infoway.io.psca/0.0.4"
+        },
+        {
+          "name": "Public Comment 0.1",
+          "ig-version": "0.0.3",
+          "package": "ca.infoway.vc.ps#0.0.3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://packages.simplifier.net/ca.infoway.vc.ps/0.0.3"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 19,
+        "extensions": 3,
+        "valuesets": 24,
+        "codeSystems": 1
+      }
+    },
+    {
+      "name": "Patient Reported Outcomes (PRO) FHIR IG",
+      "category": "Personal Healthcare",
+      "npm-name": "hl7.fhir.us.patient-reported-outcomes",
+      "description": "This IG provides the necessary guidance to use FHIR for Patient Reported Outcomes",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/patient-reported-outcomes/history.html",
+      "canonical": "http://hl7.org/fhir/us/patient-reported-outcomes",
+      "ci-build": "http://build.fhir.org/ig/HL7/patient-reported-outcomes",
+      "analysis": {
+        "rest": true
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.us.patient-reported-outcomes#0.2.0",
+          "fhir-version": [
+            "4.0.0"
+          ],
+          "url": "http://hl7.org/fhir/us/patient-reported-outcomes/2019May"
+        }
+      ]
+    },
+    {
+      "name": "Patient Request for Corrections Implementation Guide",
+      "category": "Personal Healthcare",
+      "npm-name": "hl7.fhir.uv.patient-corrections",
+      "description": "The Patient Corrections FHIR implementation guide standardizes the method of electronically exchanging the required information to facilitate the patient\u2019s request for corrections and the electronic communication that reflects the workflow of the correction process. ",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/patient-corrections/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/patient-corrections",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-patient-correction",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "carePlanning": true,
+        "profiles": 3,
+        "operations": 1,
+        "valuesets": 4,
+        "codeSystems": 4,
+        "examples": 17
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.patient-corrections#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/patient-corrections/STU1"
+        }
+      ]
+    },
+    {
+      "name": "PDSm",
+      "category": "Clinical Documents",
+      "npm-name": "ans.fhir.fr.pdsm",
+      "description": "Partage de Documents de Sant\u00e9 en mobilit\u00e9 (PDSm)",
+      "authority": "ANS (FR)",
+      "country": "fr",
+      "language": "fr",
+      "history": "https://interop.esante.gouv.fr/ig/fhir/pdsm/history.html",
+      "canonical": "https://interop.esante.gouv.fr/ig/fhir/pdsm",
+      "ci-build": "https://build.interop.esante.gouv.fr/ig/fhir/pdsm",
+      "editions": [
+        {
+          "name": "Release 17.3.2023 (3.0.0)",
+          "ig-version": "3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "package": "ans.fhir.fr.pdsm#3.0.0",
+          "url": "https://interop.esante.gouv.fr/ig/fhir/pdsm/3.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Person-Centered Outcomes (PCO) Implementation Guide",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.pco",
+      "description": "Person-Centered Outcomes (PCO) Implementation Guide",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pco/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pco",
+      "ci-build": "http://build.fhir.org/ig/HL7/pco-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.pco#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pco/2025May"
+        }
+      ]
+    },
+    {
+      "name": "Personal Health Device FHIR IG",
+      "category": "Personal Healthcare",
+      "npm-name": "hl7.fhir.uv.phd",
+      "description": "The IG provides a mapping of IEEE 11073 20601 Personal Health Device data to FHIR",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/phd/history.html",
+      "canonical": "http://hl7.org/fhir/uv/phd",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 11,
+        "valuesets": 7,
+        "codeSystems": 4
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/phd",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.uv.phd#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/phd/STU2"
+        }
+      ]
+    },
+    {
+      "name": "Pharmaceutical Clinical Trial Protocols",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.pharmaceutical-research-protocol",
+      "description": "The IG covers a range of use cases for digital representation of a Clinical Trial protocol.   The simplest use case is document oriented submission of a protocol to a Regulator. Complex use cases require detailed machine processable representation of a protocol.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/pharmaceutical-research-protocol/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/pharmaceutical-research-protocol",
+      "ci-build": "https://github.com/HL7/vulcan-udp-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.pharmaceutical-research-protocol#1.0.0-ballot",
+          "fhir-version": [
+            "6.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/pharmaceutical-research-protocol/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "Pharmaceutical Quality (Industry)",
+      "category": "Pharmaceutical",
+      "npm-name": "hl7.fhir.uv.pharm-quality",
+      "description": "The FHIR resource profiles specified in this implementation guide represent data in the ICH Quality Guidelines (https://www.ich.org/page/quality-guidelines). This implementation guide defines universal realm structured data elements to support structured authoring (e.g., master data; advanced analysis) for the creation and exchange of Quality information internationally.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/pharm-quality/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/pharm-quality",
+      "ci-build": "http://build.fhir.org/ig/HL7/uv-dx-pq",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.pharm-quality#1.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/pharm-quality/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Pharmaceutical Quality - Chemistry, Manufacturing and Controls (PQ-CMC) Submissions to FDA",
+      "category": "Pharmaceutical",
+      "npm-name": "hl7.fhir.us.pq-cmc-fda",
+      "description": "The FDA PQ-CMC FHIR IG is for submission of structured and standardized information regarding drug product quality, chemistry, manufacturing and processes controls.  This data is intended for submission to the US FDA by biopharmaceutical companies for the purpose of drug application review.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pq-cmc-fda/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pq-cmc-fda",
+      "ci-build": "http://build.fhir.org/ig/HL7/FHIR-us-pq-cmc-fda",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.pq-cmc-fda#2.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/us/pq-cmc-fda/STU2"
+        }
+      ]
+    },
+    {
+      "name": "Pharmacist Care Plan FHIR IG",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.phcp",
+      "description": "This is an electronic care plan with enhanced Medications / Immunizations content based on the templates in the HL7 Implementation Guide for C-CDA Release 2.1: Consolidated CDA for Clinical Notes, represented using FHIR profiles",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/phcp/history.html",
+      "canonical": "http://hl7.org/fhir/us/phcp",
+      "ci-build": "http://build.fhir.org/ig/HL7/PhCP",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 10,
+        "examples": 16
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.phcp#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/phcp/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Phenomics Exchange for Research and Diagnostics",
+      "category": "Clinical Observations",
+      "npm-name": "hl7.fhir.uv.phenomics-exchange",
+      "description": "This Implementation Guide provides conformance resources to support the authoring and exchange of the phenotypic picture of an individual or a group of individuals.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/phenomics-exchange/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/phenomics-exchange",
+      "ci-build": "http://build.fhir.org/ig/HL7/phenomics-exchange-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.phenomics-exchange#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/phenomics-exchange/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "PL Base (R5)",
+      "category": "Regional Base",
+      "npm-name": "hl7.fhir.pl.base.r5",
+      "description": "This guide lists the base profiles specified for the Polish realm.",
+      "authority": "HL7 Poland",
+      "country": "pl",
+      "history": "https://hl7.org.pl/fhir/ig/pl-base/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org.pl/fhir/ig/pl-base/ImplementationGuide/Hl7PlBaseIg",
+      "ci-build": "http://build.fhir.org/ig/HL7-Poland/pl-fhir-base",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "0.1.2",
+          "package": "hl7.fhir.pl.base.r5#0.1.2",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://hl7.org.pl/ig/pl-base/0.1.2"
+        }
+      ]
+    },
+    {
+      "name": "Point of Care Devices",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.pocd",
+      "description": "Defines the use of FHIR resources to convey measurements and supporting data from acute care point-of-care medical devices (PoCD) to receiving systems for electronic medical records, clinical decision support, and medical data archiving for aggregate quality measurement and research purposes",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/pocd/history.html",
+      "canonical": "http://hl7.org/fhir/uv/pocd",
+      "ci-build": "http://build.fhir.org/ig/HL7/uv-pocd",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 13,
+        "extensions": 12,
+        "valuesets": 8,
+        "codeSystems": 5,
+        "examples": 21
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.3.0",
+          "package": "hl7.fhir.uv.pocd#0.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/pocd/2021Sep"
+        }
+      ]
+    },
+    {
+      "name": "Point-of-Care Medical Device Tracking (PMDT)",
+      "category": "Administration",
+      "npm-name": "ihe.pcc.pmdt",
+      "description": "provides definition for a mobile Device",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://wiki.ihe.net/index.php/Point-of-Care_Medical_Device_Tracking",
+      "canonical": "http://wiki.ihe.net/index.php/Point-of-Care_Medical_Device_Tracking",
+      "editions": [
+        {
+          "name": "STU3 Trial-Implementation",
+          "ig-version": "0.1.0",
+          "package": "ihe.pcc.pmdt#0.1.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://wiki.ihe.net/index.php/Point-of-Care_Medical_Device_Tracking"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id ihe.pcc.pmdt#0.1.0"
+      }
+    },
+    {
+      "name": "Post Acute Orders FHIR IG",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.dme-orders",
+      "description": "Electronic exchange of post-acute orders",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/dme-orders/history.html",
+      "canonical": "http://hl7.org/fhir/us/dme-orders",
+      "ci-build": "http://build.fhir.org/ig/HL7/dme-orders",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 11,
+        "extensions": 3,
+        "valuesets": 2,
+        "codeSystems": 1,
+        "examples": 26
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.us.dme-orders#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/dme-orders/2020Sep"
+        }
+      ]
+    },
+    {
+      "name": "Potential Drug/Drug Interaction",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.uv.pddi",
+      "description": "This implementation guide is targeted at stakeholders who seek to increase the specificity and clinical relevance of drug-drug interaction alerts presented through the electronic health record. The approach is service-oriented and uses Web standards, a minimum information model for potential drug interactions, and emerging Health Information Technology standards including CDS Hooks, FHIR, and Clinical Quality Language (CQL)",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/pddi/history.html",
+      "canonical": "http://hl7.org/fhir/uv/pddi",
+      "ci-build": "http://build.fhir.org/ig/HL7/PDDI-CDS",
+      "analysis": {
+        "valuesets": 88,
+        "codeSystems": 1,
+        "examples": 36
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.pddi#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/pddi/2023Jan"
+        }
+      ]
+    },
+    {
+      "name": "Privacy Consent on FHIR (PCF)",
+      "category": "Privacy / Security",
+      "npm-name": "ihe.iti.pcf",
+      "description": "The Privacy Consent on FHIR (PCF) Profile provides support for patient privacy consents and access control where a FHIR API is used to access Document Sharing Health Information Exchanges.",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/PCF/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/PCF",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.PCF/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.1.0",
+          "package": "ihe.iti.pcf#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/PCF/1.1.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Profiles for ICSR Transfusion and Vaccination Adverse Event Detection and Reporting",
+      "category": "Pharmaceutical",
+      "npm-name": "hl7.fhir.us.icsr-ae-reporting",
+      "description": "This Implementation Guide provides a set of profiles and algorithms around the detection, validation, and reporting, as well as the eventual recording and persisting of Adverse Events associated with blood transfusions and vaccinations.  EHRs and Provider Networks can use this guide to understand the data elements needed to facilitate the electronic reporting of these adverse events as well as ways of mining their data to detect adverse events",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/icsr-ae-reporting/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/icsr-ae-reporting",
+      "ci-build": "http://build.fhir.org/ig/HL7/icsr-ae-reporting",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "profiles": 22,
+        "extensions": 20,
+        "valuesets": 13,
+        "codeSystems": 2,
+        "examples": 42
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU Update",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.us.icsr-ae-reporting#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/icsr-ae-reporting/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Protocols for Clinical Registry Extraction and Data Submission (CREDS) IG",
+      "category": "Clinical Registries",
+      "npm-name": "hl7.fhir.us.registry-protocols",
+      "description": "This guide profiles how a registry says what needs to be sent, and how a healthcare provider organization can use that to automate the collection and formatting the data into a submission, conforming to registry or FHIR implementation guide defined profiles and protocols.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/registry-protocols/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/registry-protocols",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-registry-protocols-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.registry-protocols#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/registry-protocols/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Provider Directory IG",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.au.pd",
+      "description": "This implementation guide is based upon STU3 FHIR standard and is the Australian variant of the Provider Directory IG. It outlines the key data elements for any provider directory and basic query guidance. The components developed in this guide are intended to provide a foundation for a central or distributed Provider or Healthcare Directory",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "au",
+      "history": "http://hl7.org.au/fhir/pd/history.html",
+      "canonical": "http://hl7.org.au/fhir/pd",
+      "ci-build": "http://build.fhir.org/ig/hl7au/au-fhir-pd",
+      "editions": [
+        {
+          "name": "Release 1 Qa-preview",
+          "ig-version": "0.6.0",
+          "package": "hl7.fhir.au.pd#0.6.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org.au/fhir"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to find package hl7.fhir.au.pd#0.6.0"
+      },
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "QICore",
+      "category": "Quality / CDS",
+      "npm-name": "hl7.fhir.us.qicore",
+      "description": "QICore defines a uniform way for quality measurement and decision support knowledge to refer to clinical data. The profiles align as much as possible with DAF and incorporate content from the (Quality Data Model) and the (Virtual Medical Record) specifications",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/qicore/history.html",
+      "canonical": "http://hl7.org/fhir/us/qicore",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-qi-core",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "profiles": 51,
+        "extensions": 8,
+        "valuesets": 21,
+        "codeSystems": 5,
+        "examples": 66
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 7",
+          "ig-version": "7.0.2",
+          "package": "hl7.fhir.us.qicore#7.0.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/qicore/STU7.0.2"
+        }
+      ]
+    },
+    {
+      "name": "Quality Measure Implementation Guide",
+      "category": "Quality / CDS",
+      "npm-name": "hl7.fhir.us.cqfmeasures",
+      "description": "Provides profiles and guidance for the representation of clinical quality measures in FHIR and Clincal Quality Language (CQL)",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/cqfmeasures/history.html",
+      "canonical": "http://hl7.org/fhir/us/cqfmeasures",
+      "ci-build": "http://build.fhir.org/ig/HL7/cqf-measures",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "measures": true,
+        "profiles": 21,
+        "extensions": 36,
+        "operations": 6,
+        "valuesets": 5,
+        "codeSystems": 5,
+        "examples": 61
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU5 (v5.0.0)",
+          "ig-version": "5.0.0",
+          "package": "hl7.fhir.us.cqfmeasures#5.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cqfmeasures/STU5"
+        },
+        {
+          "name": "STU4 (v4.0.0)",
+          "ig-version": "4.0.0",
+          "package": "hl7.fhir.us.cqfmeasures#4.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cqfmeasures/STU4"
+        },
+        {
+          "name": "STU3",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.us.cqfmeasures#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cqfmeasures/STU3"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.cqfmeasures#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cqfmeasures/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.cqfmeasures#1.0.0",
+          "fhir-version": [
+            "3.0.2"
+          ],
+          "url": "http://hl7.org/fhir/us/cqfmeasures/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Quality Measure Implementation Guide",
+      "category": "Quality / CDS",
+      "npm-name": "hl7.fhir.uv.cqm",
+      "description": "The Quality Measure Implementation Guide (QM IG) describes an approach to representing Quality Measures (QMs) using the FHIR Clinical Reasoning Module and Clinical Quality Language (CQL). This Implementation Guide can be used for multiple use cases across many domains.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cqm/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cqm",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-cqm",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.cqm#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cqm/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Radiation Dose Summary for Diagnostic Procedures on FHIR",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.uv.radiation-dose-summary",
+      "description": "Provides a summary of the DICOM radiation dose report in FHIR related to imaging procedures.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/radiation-dose-summary/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/radiation-dose-summary",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-radiation-dose-summary-ig",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 9,
+        "valuesets": 5,
+        "codeSystems": 1,
+        "tests": 3,
+        "examples": 15
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.1.0",
+          "package": "hl7.fhir.uv.radiation-dose-summary#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/radiation-dose-summary/2022Jan"
+        }
+      ]
+    },
+    {
+      "name": "Real Time Location Services Implementation Guide",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.uv.rtls",
+      "description": "This implementation guide defines the use of FHIR resources to exchange real time data about where patients, staff, device, or other assets are located within a hospital or other healthcare facility. This data is typically exchanged between a healthcare system and a Real Time Location System (RTLS) that captures, processes, and stores information about the location of tracking tags.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/rtls/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/rtls",
+      "ci-build": "http://build.fhir.org/ig/HL7/rtls-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.0 Ballot",
+          "ig-version": "1.0.0-ballot2",
+          "package": "hl7.fhir.uv.rtls#1.0.0-ballot2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/rtls/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "Reference Architecture",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.ra",
+      "description": "The Reference Architecture Implementation Guide to be used as a starting point for building infrastructure with the SMART Guidelines approach",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/ra/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/ra",
+      "ci-build": "http://worldhealthorganization.github.io/smart-ra",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.1.0",
+          "package": "smart.who.int.ra#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/ra/v0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "Respiratory Virus Hospitalization Surveillance Network (RESP-NET) Content Implementation Guide",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.resp-net",
+      "description": "The Respiratory Virus Hospitalization Surveillance Network (RESP-NET) comprises three platforms that conduct population-based surveillance for laboratory-confirmed hospitalizations associated with COVID-19, Influenza, and Respiratory Syncytial Virus (RSV) among children and adults.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/resp-net/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/resp-net",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-resp-net-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2 Ballot",
+          "ig-version": "2.0.0-ballot",
+          "package": "hl7.fhir.us.resp-net#2.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/resp-net/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "Retrieval of Real World Data for Clinical Research",
+      "category": "Research",
+      "npm-name": "hl7.fhir.uv.vulcan-rwd",
+      "description": "This IG provides profiles that define the data needed from EHRs to answer research questions arising from clinical studies.  It will demonstrate how FHIR and EHRs can directly support clinical trials.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/vulcan-rwd/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/vulcan-rwd",
+      "ci-build": "http://build.fhir.org/ig/HL7/vulcan-rwd",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.vulcan-rwd#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/vulcan-rwd/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Risk Based Contracts Member Attribution List FHIR IG",
+      "category": "Financial",
+      "npm-name": "hl7.fhir.us.davinci-atr",
+      "description": "Support the real-time exchange of alerts and notifications that impact patient care and value based or risk based services.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-atr/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-atr",
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-atr",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 8,
+        "extensions": 5,
+        "valuesets": 1,
+        "codeSystems": 1,
+        "examples": 14
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.davinci-atr#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-atr/STU2.1"
+        },
+        {
+          "name": "STU2 Release 1",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.davinci-atr#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-atr/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-atr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-atr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "RIVO-Noord Zorgviewer",
+      "npm-name": "hl7.fhir.nl.zorgviewer",
+      "category": "EHR Access",
+      "description": "De zorgviewer biedt zorgverleners een 360\u00b0 beeld van de pati\u00ebnt of cli\u00ebnt. Opgebouwd uit alle beschikbare zorginformatie, waarvoor de pati\u00ebnt of cli\u00ebnt toestemming heeft gegeven.",
+      "authority": "RIVO-Noord (NL)",
+      "product": [
+        "fhir"
+      ],
+      "country": "nl",
+      "language": [
+        "nl"
+      ],
+      "history": "https://implementatiegids.zorgviewer.nl/changes.html",
+      "canonical": "http://fhir.hl7.nl/zorgviewer",
+      "ci-build": "https://build.fhir.org/ig/RIVO-Noord/zorgviewer-ig",
+      "editions": [
+        {
+          "name": "Sprint 70",
+          "ig-version": "1.21.0",
+          "package": "hl7.fhir.nl.zorgviewer#1.21.0",
+          "fhir-version": [
+            "3.0.2"
+          ],
+          "url": "https://implementatiegids.zorgviewer.nl"
+        }
+      ]
+    },
+    {
+      "name": "Scalable Consent Management",
+      "category": "Privacy / Security",
+      "npm-name": "hl7.fhir.us.consent-management",
+      "description": "Patient Consent management is the central component in a consent ecosystem and at the core of a scalable consent architecture.  This guide provides operations and profiles to enable the answering the question `is it possible to answer the question provider X have authority to view healthcare data Y about patient Z?` across a set of consent management repositories.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/consent-management/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/consent-management",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-consent-management",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.consent-management#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/consent-management/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "SDC (Structured Data Capture)",
+      "category": "Forms Management",
+      "npm-name": "hl7.fhir.uv.sdc",
+      "description": "Defines expectations for sharing of Questionnaires and answers, including mechanisms for automatically populating portions of a questionnaire based on embedded mappings to underlying data elements",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/sdc/history.html",
+      "canonical": "http://hl7.org/fhir/uv/sdc",
+      "ci-build": "http://build.fhir.org/ig/HL7/sdc",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "questionnaire": true,
+        "profiles": 26,
+        "extensions": 42,
+        "logicals": 2,
+        "operations": 7,
+        "valuesets": 9,
+        "codeSystems": 7,
+        "examples": 48
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 4",
+          "ig-version": "4.0.0",
+          "package": "hl7.fhir.uv.sdc#4.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/sdc/STU4"
+        }
+      ]
+    },
+    {
+      "name": "SDC Data Elements Registry",
+      "category": "Forms Management",
+      "npm-name": "hl7.fhir.us.sdcde",
+      "description": "Defines expectations for sharing of data elements between registries",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/sdcde/history.html",
+      "canonical": "http://hl7.org/fhir/us/sdcde",
+      "ci-build": "http://build.fhir.org/ig/HL7/sdc-de",
+      "analysis": {
+        "error": "Unable to resolve package id hl7.fhir.us.sdcde#1.0.2"
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0",
+          "package": "hl7.fhir.us.sdcde#2.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/sdcde/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.2",
+          "package": "hl7.fhir.us.sdcde#1.0.2",
+          "fhir-version": [
+            "1.0.2"
+          ],
+          "url": "http://hl7.org/fhir/DSTU2/sdcde/sdcde.html"
+        }
+      ]
+    },
+    {
+      "name": "SDOH Clinical Care for Multiple Domains",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.sdoh-clinicalcare",
+      "description": "Profiles on FHIR R4 resources (using US Core as the basis where possible) used to document social determinants of health (SDOH) for an individual which covers many different factors considered social risks and social needs, e.g. Food Insecurity, Housing Stability and Quality, Transportation Access and others. The IG covers use cases identified from the clinical care setting that include : assessment of SDOH risks; evaluation of which risks can be addressed; setting goals,  documenting and tracking to completion SDOH interventions; and sharing SDOH information for an individual with organizations for secondary uses.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/sdoh-clinicalcare/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/sdoh-clinicalcare",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-sdoh-clinicalcare",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 9,
+        "valuesets": 6,
+        "codeSystems": 1,
+        "examples": 31
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 3 Ballot",
+          "ig-version": "3.0.0-ballot",
+          "package": "hl7.fhir.us.sdoh-clinicalcare#3.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/sdoh-clinicalcare/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "Security for Scalable Registration, Authentication, and Authorization",
+      "category": "Privacy / Security",
+      "npm-name": "hl7.fhir.us.udap-security",
+      "description": "This implementation guide describes how to extend OAuth 2.0 to support secure and scalable workflows for business-to-business (B2B) apps that implement the client credentials flow or authorization code flow. ",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/udap-security/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/udap-security",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-udap-security-ig",
+      "analysis": {
+        "rest": true
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.udap-security#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/udap-security/2025Jan"
+        },
+        {
+          "name": "STU Update",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.udap-security#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/udap-security/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.udap-security#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/udap-security/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Sharing eCC Data from Pathology Labs to EHR",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.us.cancer-reporting",
+      "description": "Integrating the Healthcare Enterprise (IHE) Structured Data Capture (SDC) on FHIR uses a form-driven workflow to capture and transmit encoded data by creating FHIR Observations. The primary use case for this is transmitting data captured in College of American Pathologists electronic Cancer Checklists (eCCs), which are distributed as IHE SDC templates.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/cancer-reporting/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/cancer-reporting",
+      "ci-build": "http://build.fhir.org/ig/HL7/cancer-reporting",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "diagnostics": true,
+        "profiles": 6,
+        "valuesets": 1,
+        "codeSystems": 1,
+        "examples": 27
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.cancer-reporting#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/cancer-reporting/STU2"
+        }
+      ]
+    },
+    {
+      "name": "Sharing of IPS (sIPS)",
+      "category": "Clinical Documents",
+      "npm-name": "ihe.iti.sips",
+      "description": "Defines how HL7 FHIR IPS is communicated using IHE Document Sharing",
+      "authority": "IHE",
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/sIPS/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/sIPS",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.sIPS/branches/master/index.html",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.0.0",
+          "package": "ihe.iti.sips#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/sIPS/1.0.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "Sharing Valuesets, Codes, and Maps (SVCM)",
+      "category": "Terminology",
+      "npm-name": "ihe.iti.svcm",
+      "description": "The Sharing Valuesets, Codes, and Maps (SVCM) Profile defines a lightweight interface through which healthcare systems may retrieve centrally managed uniform nomenclature and mappings between code systems based on the HL7 Fast Healthcare Interoperability Resources (FHIR) specification.",
+      "authority": "IHE",
+      "product": [
+        "fhir"
+      ],
+      "country": "uv",
+      "history": "https://profiles.ihe.net/ITI/SVCM/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://profiles.ihe.net/ITI/SVCM",
+      "ci-build": "http://build.fhir.org/ig/IHE/ITI.SVCM",
+      "editions": [
+        {
+          "name": "Publication",
+          "ig-version": "1.5.1",
+          "package": "ihe.iti.svcm#1.5.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://profiles.ihe.net/ITI/SVCM/1.5.1"
+        }
+      ]
+    },
+    {
+      "name": "Single Institutional Review Board (sIRB) Implementation Guide",
+      "category": "Research",
+      "npm-name": "hl7.fhir.us.sirb",
+      "description": "This IG covers questionnaires and questionnaire responses in support of capturing and exchange of standardized forms in support of a single IRB (Institutional Review Board) where a single IRB will expedite approval for a project but still need to send all documentation to multiple relying IRBs.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/sirb/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/sirb",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-sirb",
+      "analysis": {
+        "codeSystems": 1,
+        "examples": 16
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.sirb#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/sirb/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Situational Awareness for Novel Epidemic Response",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.uv.saner",
+      "description": "The SANER Implementation Guide enables transmission of high level situational awareness information from inpatient facilities to centralized data repositories to support the treatment of novel influenza-like illness.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/saner/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/saner",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-saner",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "measures": true,
+        "profiles": 10,
+        "extensions": 5,
+        "operations": 5,
+        "valuesets": 49,
+        "codeSystems": 6,
+        "examples": 169
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.saner#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/saner/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Smart App Launch Implementation Guide",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.uv.smart-app-launch",
+      "description": "App access to Healthcare software",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/smart-app-launch/history.html",
+      "canonical": "http://hl7.org/fhir/smart-app-launch",
+      "ci-build": "http://build.fhir.org/ig/HL7/smart-app-launch",
+      "analysis": {},
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2.2",
+          "ig-version": "2.2.0",
+          "package": "hl7.fhir.uv.smart-app-launch#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/smart-app-launch/STU2.2"
+        },
+        {
+          "name": "STU 2.1",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.uv.smart-app-launch#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/smart-app-launch/STU2.1"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.uv.smart-app-launch#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/smart-app-launch/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.smart-app-launch#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/smart-app-launch/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART Base",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.base",
+      "description": "Base SMART Guidelines implementation guide to be used as the base dependency for all SMART Guidelines IGs",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/base/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/base",
+      "ci-build": "http://worldhealthorganization.github.io/smart-base",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases Draft",
+          "ig-version": "0.2.0",
+          "package": "smart.who.int.base#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/base/0.2.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK BDS",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-bds",
+      "description": "SMART Digital Adaptation Kit (DAK) for birth defects surveillance (BDS)",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-bds/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-bds",
+      "ci-build": "http://worldhealthorganization.github.io/dak-bds",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "smart.who.int.dak-bds#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-bds/v1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK CCC",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-ccc",
+      "description": "SMART Guidelines Digital Adaptation Kit (DAK) for Clinical Care in Crises (CCC)",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-ccc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-ccc",
+      "ci-build": "http://worldhealthorganization.github.io/smart-dak-ccc",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "smart.who.int.dak-ccc#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-ccc/v1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK IMMZ",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-immz",
+      "description": "SMART Guidelines Digital Adaptation Kit (DAK) for Immunizations",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-immz/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-immz",
+      "ci-build": "http://worldhealthorganization.github.io/smart-dak-immz",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.1.0",
+          "package": "smart.who.int.dak-immz#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-immz/v1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK PNC",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-pnc",
+      "description": "SMART Digital Adaptation Kit (DAK) for Postnatal Care",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-pnc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-pnc",
+      "ci-build": "http://worldhealthorganization.github.io/smart-dak-pnc",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "smart.who.int.dak-pnc#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-pnc/v1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK SMBP",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-smbp",
+      "description": "SMART Digital Adaptation Kit (DAK) for self-monitoring of blood pressure in pregnancy (SMBP)",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-smbp/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-smbp",
+      "ci-build": "http://worldhealthorganization.github.io/smart-dak-smbp",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.0",
+          "package": "smart.who.int.dak-smbp#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-smbp/v1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK SRV",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-srv",
+      "description": "SMART Digital Adaptation Kit (DAK) for Surveillance",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-srv/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-srv",
+      "ci-build": "http://worldhealthorganization.github.io/smart-dak-srv",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.9.9",
+          "package": "smart.who.int.dak-srv#0.9.9",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-srv/v0.9.9"
+        }
+      ]
+    },
+    {
+      "name": "SMART DAK TB",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.dak-tb",
+      "description": "SMART Guidelines Digital Adaptation Kit (DAK) for tuberculosis (TB)",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/dak-tb/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/dak-tb",
+      "ci-build": "http://worldhealthorganization.github.io/smart-dak-tb",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.0.1",
+          "package": "smart.who.int.dak-tb#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/dak-tb/v1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "SMART Guidelines Starter Kit",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.ig-starter-kit",
+      "description": "SMART Guidelines Starter Kit",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/ig-starter-kit/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/ig-starter-kit",
+      "ci-build": "http://worldhealthorganization.github.io/smart-ig-starter-kit",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "2.0.0",
+          "package": "smart.who.int.ig-starter-kit#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/ig-starter-kit/v2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART Health Cards and Links FHIR IG",
+      "category": "Communications",
+      "npm-name": "hl7.fhir.uv.smart-health-cards-and-links",
+      "description": "This Implementation Guide defines secure, standards-based mechanisms for individuals to store, share, and manage their health data. It encompasses SMART Health Cards (SHC) for verifiable clinical records and SMART Health Links (SHL) for flexible sharing of FHIR data, including patient-supplied information, dynamic records, and authorization delegation.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/smart-health-cards-and-links/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/smart-health-cards-and-links",
+      "ci-build": "http://build.fhir.org/ig/HL7/smart-health-cards-and-links",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.smart-health-cards-and-links#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/smart-health-cards-and-links/STU1"
+        }
+      ]
+    },
+    {
+      "name": "SMART Health Cards Vaccination and Testing, Release 1 | STU 1",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.uv.shc-vaccination",
+      "description": "Defines the clinical and patient information contained within a SMART Health Card (SHC) related to vaccination and lab results related to an infectious disease like COVID-19.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/shc-vaccination/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/shc-vaccination",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 16,
+        "valuesets": 10,
+        "codeSystems": 1
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "0.6.2",
+          "package": "hl7.fhir.uv.shc-vaccination#0.6.2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/shc-vaccination/2021Sep"
+        }
+      ]
+    },
+    {
+      "name": "SMART ICVP",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.icvp",
+      "description": "SMART Guidelines for International Certificate for Vaccination or Prophylaxis",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/icvp/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/icvp",
+      "ci-build": "http://worldhealthorganization.github.io/smart-icvp",
+      "editions": [
+        {
+          "name": "Releases Draft",
+          "ig-version": "0.3.0",
+          "package": "smart.who.int.icvp#0.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/icvp/0.3.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "SMART PCMT",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.pcmt",
+      "description": "SMART Product Catalog",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/pcmt/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/pcmt",
+      "ci-build": "http://worldhealthorganization.github.io/pcmt",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.1.0",
+          "package": "smart.who.int.pcmt#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/pcmt/v0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART Product Dataset for Prequalified Vaccines",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.pcmt-vaxprequal",
+      "description": "Data exchange specifications for Product Catalog supporting the SMART Guidelines",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/pcmt-vaxprequal/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/pcmt-vaxprequal",
+      "ci-build": "http://worldhealthorganization.github.io/smart-pcmt-vaxprequal",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.2.0",
+          "package": "smart.who.int.pcmt-vaxprequal#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/pcmt-vaxprequal/v0.2.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART Trust",
+      "category": "Privacy / Security",
+      "npm-name": "smart.who.int.trust",
+      "description": "SMART Trust Implementation Guide",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/trust/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/trust",
+      "ci-build": "http://worldhealthorganization.github.io/smart-trust",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "1.4.0",
+          "package": "smart.who.int.trust#1.4.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://smart.who.int/trust/1.4.0"
+        }
+      ]
+    },
+    {
+      "name": "SMART TRUST PHW",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.trust-phw",
+      "description": "Specifications for usage of Personal Health Wallet (PHW) with WHO GDHCN Trust Network",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/trust-phw/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/trust-phw",
+      "ci-build": "http://worldhealthorganization.github.io/smart-trust-phw",
+      "editions": [
+        {
+          "name": "Releases Draft",
+          "ig-version": "0.1.0",
+          "package": "smart.who.int.trust-phw#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/trust-phw/0.1.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "SMART TS",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.ts",
+      "description": "SMART Guidelines Terminology artifacts and resources to be used as the across all SMART Guidelines IGs",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/ts/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/ts",
+      "ci-build": "http://worldhealthorganization.github.io/smart-ts",
+      "editions": [
+        {
+          "name": "Releases Draft",
+          "ig-version": "0.1.0",
+          "package": "smart.who.int.ts#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/ts/0.1.0"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "SMART Verifiable IPS for Pilgrimage",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.ips-pilgrimage",
+      "description": "SMART Verifiable IPS for Pilgrimage",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/ips-pilgrimage/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/ips-pilgrimage",
+      "ci-build": "http://worldhealthorganization.github.io/smart-ips-pilgrimage",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "2.0.3",
+          "package": "smart.who.int.ips-pilgrimage#2.0.3",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/ips-pilgrimage/2.0.3"
+        }
+      ]
+    },
+    {
+      "name": "SMART Web Messaging Implementation Guide: STU1",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.uv.smart-web-messaging",
+      "description": "SMART Web Messaging enables tight UI integration between EHRs and embedded SMART apps via HTML5\u2019s Web Messaging. SMART Web Messaging allows applications to push unsigned orders, note snippets, risk scores, or UI suggestions directly to the clinician\u2019s EHR session. Built on the browser\u2019s javascript window.postMessage function, SMART Web Messaging is a simple, native API for health apps embedded within the user\u2019s workflow",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/smart-web-messaging/history.html",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/HL7/smart-web-messaging",
+      "canonical": "http://hl7.org/fhir/uv/smart-web-messaging",
+      "analysis": {
+        "examples": 1
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.smart-web-messaging#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/smart-web-messaging/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Specialty Medication Enrollment",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.us.specialty-rx",
+      "description": "This FHIR IG focuses on the exchange of data (Demographic, prescription, clinical and financial) for dispensing specialty medications by pharmacies as well as facilitating the enrollment of patients in programs offered by third parties such as but not limited to Hub vendors and Pharmaceutical manufacturers.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/specialty-rx/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/specialty-rx",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "messaging": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 18,
+        "valuesets": 2,
+        "codeSystems": 4,
+        "examples": 16
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-specialty-rx",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.specialty-rx#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/specialty-rx/STU2"
+        },
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.specialty-rx#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/specialty-rx/STU1"
+        }
+      ]
+    },
+    {
+      "name": "SQL on FHIR",
+      "category": "Infrastructure",
+      "npm-name": "org.sql-on-fhir.ig",
+      "description": "A specification for defining portable views of FHIR data that can be easily queried using tools such as SQL.",
+      "authority": "SQL on FHIR Working Group",
+      "country": "uv",
+      "history": "https://sql-on-fhir.org/ig/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://sql-on-fhir.org/ig",
+      "ci-build": "https://build.fhir.org/ig/FHIR/sql-on-fhir-v2",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "2.0.0",
+          "ig-version": "2.0.0",
+          "package": "org.sql-on-fhir.ig#2.0.0",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://sql-on-fhir.org/ig/2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "Standard Personal Health Record",
+      "category": "Personal Healthcare",
+      "npm-name": "hl7.fhir.uv.phr",
+      "description": "A specifcation for a standard personal health record file format, for collecting and assembling longitudinal records from multiple EHR vendors.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/phr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/phr",
+      "ci-build": "http://build.fhir.org/ig/HL7/personal-health-record-format-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot2",
+          "package": "hl7.fhir.uv.phr#1.0.0-ballot2",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/phr/2025May"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions R5 Backport",
+      "category": "EHR Access",
+      "npm-name": "hl7.fhir.uv.subscriptions-backport",
+      "description": "This guide defines a standard method of back-porting the R5 subscriptions API to R4 implementations as to bridge for pre-adopting R5 Subscriptions prior to adoption of the R5 FHIR standard.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/subscriptions-backport/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/subscriptions-backport",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-subscription-backport-ig",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "profiles": 4,
+        "extensions": 7,
+        "operations": 2,
+        "valuesets": 4,
+        "codeSystems": 4,
+        "examples": 9
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.2 Ballot",
+          "ig-version": "1.2.0-ballot",
+          "package": "hl7.fhir.uv.subscriptions-backport#1.2.0-ballot",
+          "fhir-version": [
+            "4.3.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/subscriptions-backport/2024Jan"
+        },
+        {
+          "name": "STU 1.1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.uv.subscriptions-backport#1.1.0",
+          "fhir-version": [
+            "4.3.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/subscriptions-backport/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.subscriptions-backport#1.0.0",
+          "fhir-version": [
+            "4.3.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/subscriptions-backport/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Swiss Cancer Registration Implementation Guide (CH-CRL)",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-crl",
+      "description": "Implementation guide for the Cancer Registry Law (CRL)",
+      "authority": "FOPH (CH)",
+      "product": [
+        "fhir"
+      ],
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-crl/history.html",
+      "canonical": "http://fhir.ch/ig/ch-crl",
+      "ci-build": "http://build.fhir.org/ig/ahdis/ch-crl/index.html",
+      "editions": [
+        {
+          "name": "STU",
+          "ig-version": "0.2.1",
+          "package": "ch.fhir.ig.ch-crl#0.2.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-crl"
+        },
+        {
+          "name": "STU",
+          "ig-version": "0.1.1",
+          "package": "ch.fhir.ig.ch-crl#0.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-crl/0.1.1"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "clinicalCore": true,
+        "carePlanning": true,
+        "profiles": 34,
+        "extensions": 1,
+        "logicals": 1,
+        "valuesets": 15,
+        "codeSystems": 15,
+        "examples": 137
+      },
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Swiss Core Implementation Guide",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-core",
+      "description": "Base swiss national implementation guide",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-core/history.html",
+      "canonical": "http://fhir.ch/ig/ch-core",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-core",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 5",
+          "ig-version": "5.0.0",
+          "package": "ch.fhir.ig.ch-core#5.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-core/5.0.0"
+        }
+      ],
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Swiss eMedication Implementation Guide",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.ch-emed",
+      "description": "The CH EMED implementation guide describes the FHIR representation of the defined documents for the exchange of medication information",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/ch-emed/history.html",
+      "canonical": "http://fhir.ch/ig/ch-emed",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ch-emed",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 5",
+          "ig-version": "5.0.0",
+          "package": "ch.fhir.ig.ch-emed#5.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/ch-emed/5.0.0"
+        }
+      ],
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Swiss Guide Template",
+      "category": "National Base",
+      "npm-name": "ch.fhir.ig.template",
+      "description": "HL7 Switzerland FHIR Implementation Guide Template",
+      "authority": "HL7 Switzerland",
+      "country": "ch",
+      "history": "http://fhir.ch/ig/template/history.html",
+      "canonical": "http://fhir.ch/ig/template",
+      "ci-build": "http://build.fhir.org/ig/hl7ch/ig-template/index.html",
+      "editions": [
+        {
+          "name": "STU",
+          "ig-version": "0.4.0",
+          "package": "ch.fhir.ig.template#0.4.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.ch/ig/template/0.4.0"
+        }
+      ],
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "Symptoms Data Standards",
+      "category": "Clinical",
+      "npm-name": "hl7.fhir.uv.symptoms",
+      "description": "This Implementation Guide defines how to represent and exchange standardized symptom data using FHIR to support improved diagnostic accuracy and patient outcomes. It is intended for EHR vendors, developers, and implementers who need to capture and share symptom information consistently across systems and care settings.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/symptoms/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/symptoms",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-symptoms-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.symptoms#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/symptoms/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Taiwan Digital COVID-19 Certificate",
+      "category": "Medication / Immunization",
+      "npm-name": "dccfhirig.mohw.gov.tw",
+      "description": "Taiwan Digital COVID-19 Certificate",
+      "authority": "MOHW (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://dccfhirig.mohw.gov.tw/fhir/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "https://dccfhirig.mohw.gov.tw/ig",
+      "ci-build": "https://dccfhirig.mohw.gov.tw/ig",
+      "editions": [
+        {
+          "name": "DSTU 1",
+          "ig-version": "1.1.1",
+          "package": "dccfhirig.mohw.gov.tw#1.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://dccfhirig.mohw.gov.tw/ig"
+        }
+      ]
+    },
+    {
+      "name": "Terminology Change Set Exchange",
+      "category": "Terminology",
+      "npm-name": "hl7.fhir.uv.termchangeset",
+      "description": "This IG provides profiles and implementation guidance for exchanging terminology change sets that include full semantic detail from the source terminology utilizing the CodeSystem resource.  It also addresses exchanging terminology change sets containing provisional concepts not yet incorporated in source terminologies. Analysis of semantic detail to include in a change set is informed by the Tinkar Standardized Terminology Knowledgebase (https://www.hl7.org/implement/standards/product_brief.cfm?product_id=573) Reference Model, and mappings from that model are included on CodeSystem profiles.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/termchangeset/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/termchangeset",
+      "ci-build": "http://build.fhir.org/ig/HL7/termchangeset-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.termchangeset#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/termchangeset/2024Sep"
+        }
+      ]
+    },
+    {
+      "name": "TW Core",
+      "category": "National Base",
+      "npm-name": "tw.gov.mohw.twcore",
+      "description": "Taiwan Core Implementation Guide",
+      "authority": "MOHW (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://twcore.mohw.gov.tw/ig/twcore/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://twcore.mohw.gov.tw/ig/twcore",
+      "ci-build": "https://build.fhir.org/ig/TU9IVy1UV0NvcmVJRw/VFcgQ29yZSBJRyBJVFJJ",
+      "editions": [
+        {
+          "name": "STU 1.0.0",
+          "ig-version": "1.0.0",
+          "package": "tw.gov.mohw.twcore#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://twcore.mohw.gov.tw/ig/twcore/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "TWCI",
+      "category": "Administration",
+      "npm-name": "tw.gov.mohw.nhi.ci",
+      "description": "Taiwan NHI Catastrophic Illness Implementation Guide",
+      "authority": "NHIA (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://nhicore.nhi.gov.tw/ci/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://nhicore.nhi.gov.tw/ci",
+      "ci-build": "https://build.fhir.org/ig/TWNHIFHIR/ci",
+      "editions": [
+        {
+          "name": "STU1.0.1",
+          "ig-version": "1.0.1",
+          "package": "tw.gov.mohw.nhi.ci#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://nhicore.nhi.gov.tw/ci/1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "TWIDIR",
+      "category": "Medication / Immunization",
+      "npm-name": "tw.gov.mohw.cdc.twidir",
+      "description": "Taiwan Infectious Disease Inspection Report Implementation Guide",
+      "authority": "CDC (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://twidir.cdc.gov.tw/twidir/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://twidir.cdc.gov.tw/twidir",
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.4.0",
+          "package": "tw.gov.mohw.cdc.twidir#1.4.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://twidir.cdc.gov.tw/twidir/1.4.0"
+        }
+      ]
+    },
+    {
+      "name": "TWNGS",
+      "category": "Clinical Documents",
+      "npm-name": "tw.gov.mohw.nhi.ngs",
+      "description": "Taiwan NHI Next Generation Sequencing Implementation Guide",
+      "authority": "NHIA (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://nhicore.nhi.gov.tw/ngs/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://nhicore.nhi.gov.tw/ngs",
+      "ci-build": "https://build.fhir.org/ig/TWNHIFHIR/ngs",
+      "editions": [
+        {
+          "name": "STU1.0.0",
+          "ig-version": "1.0.0",
+          "package": "tw.gov.mohw.nhi.ngs#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://nhicore.nhi.gov.tw/ngs/1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "TWPAS",
+      "category": "Financial",
+      "npm-name": "tw.gov.mohw.nhi.pas",
+      "description": "Taiwan NHI Cancer Prior Authorization Support Implementation Guide",
+      "authority": "NHIA (TW)",
+      "product": [
+        "fhir"
+      ],
+      "country": "tw",
+      "history": "https://nhicore.nhi.gov.tw/pas/history.html",
+      "language": [
+        "zh-TW"
+      ],
+      "canonical": "https://nhicore.nhi.gov.tw/pas",
+      "ci-build": "https://build.fhir.org/ig/TWNHIFHIR/pas",
+      "editions": [
+        {
+          "name": "STU1.1.1",
+          "ig-version": "1.1.1",
+          "package": "tw.gov.mohw.nhi.pas#1.1.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "https://nhicore.nhi.gov.tw/pas/1.1.1"
+        }
+      ]
+    },
+    {
+      "name": "U.S. Physical Activity IG",
+      "category": "Care Management",
+      "npm-name": "hl7.fhir.us.physical-activity",
+      "description": "Defines U.S. interoperability expectations related to physical activity, including primary assessment, supporting measures, plans, goals, referrals and patient-engagement.  Supports interoperability between care managers (e.g. EHRs, community health systems, etc.), service providers (physical activity professionals including exercise physiologists, personal trainers, community fitness centers, etc.), as well as patient-facing applications.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/physical-activity/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/physical-activity",
+      "ci-build": "http://build.fhir.org/ig/HL7/physical-activity",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.0",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.physical-activity#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/physical-activity/STU1"
+        }
+      ]
+    },
+    {
+      "name": "US Behavioral Health Profiles",
+      "category": "Care Management",
+      "npm-name": "fhir.astp.bhp",
+      "description": "The United States Core Data for Interoperability (USCDI) Plus Behavioral Health (BH) dataset (also referred to as USCDI+ BH) aims to enhance the exchange and interoperability of behavioral health information across healthcare systems in the United States. Building on the USCDI foundation, this dataset addresses the unique needs and challenges associated with behavioral health data. It is designed to facilitate behavioral health integration with other healthcare services, support better clinical decision-making, and improve patient outcomes.",
+      "authority": "US Government",
+      "country": "us",
+      "history": "http://fhir.org/guides/astp/bhp/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://fhir.org/guides/astp/bhp",
+      "ci-build": " http://build.fhir.org/guides/astp/bhp",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "0.1.0",
+          "ig-version": "0.1.0",
+          "package": "fhir.astp.bhp#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://fhir.org/guides/astp/bhp/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "US Breast Cancer Data",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.us.breastcancer",
+      "description": "Logical models and FHIR profiles for supporting breast cancer staging estimation, including the traditional three-component staging involving primary tumor classification, regional lymph nodes and distant metastases, as well as other factors important to prognosis and recurrence risk, such as tumor grade, hormone receptor status (progesterone and estrogen), as well as human epidermal growth factor 2 (HER 2) status",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/breastcancer/history.html",
+      "canonical": "http://hl7.org/fhir/us/breastcancer",
+      "ci-build": "http://build.fhir.org/ig/HL7/us-breastcancer",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "diagnostics": true,
+        "profiles": 57,
+        "extensions": 46,
+        "logicals": 260,
+        "valuesets": 35,
+        "codeSystems": 9
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Draft",
+          "ig-version": "0.2.0",
+          "package": "hl7.fhir.us.breastcancer#0.2.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/breastcancer/2018Sep"
+        }
+      ]
+    },
+    {
+      "name": "US Core",
+      "category": "National Base",
+      "npm-name": "hl7.fhir.us.core",
+      "description": "Base US national implementation guide",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "implementations": [
+        {
+          "name": "Test Server",
+          "type": "server",
+          "url": "http://test.fhir.org"
+        },
+        {
+          "name": "Source Code",
+          "type": "source",
+          "url": "http://github.com/HealthIntersections/fhirserver"
+        }
+      ],
+      "history": "http://hl7.org/fhir/us/core/history.html",
+      "canonical": "http://hl7.org/fhir/us/core",
+      "ci-build": "http://build.fhir.org/ig/HL7/US-Core",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 42,
+        "extensions": 5,
+        "operations": 1,
+        "valuesets": 31,
+        "codeSystems": 4,
+        "examples": 111
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU9 Ballot",
+          "ig-version": "9.0.0-ballot",
+          "package": "hl7.fhir.us.core#9.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/core/2026Jan"
+        }
+      ]
+    },
+    {
+      "name": "US Drug Formulary",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.Davinci-drug-formulary",
+      "description": "API-based data exchange to Third-Party Applications via Member-authorized sharing of Health Plan's Prescription Drug Formulary.",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/Davinci-drug-formulary/history.html",
+      "canonical": "http://hl7.org/fhir/us/Davinci-drug-formulary",
+      "ci-build": "https://build.fhir.org/ig/HL7/davinci-pdex-formulary",
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.Davinci-drug-formulary#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/Davinci-drug-formulary/STU1"
+        }
+      ],
+      "analysis": {
+        "content": true,
+        "medsMgmt": true,
+        "profiles": 2,
+        "extensions": 13,
+        "valuesets": 4,
+        "codeSystems": 4,
+        "examples": 11
+      },
+      "language": [
+        "en"
+      ]
+    },
+    {
+      "name": "US Drug Formulary",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.davinci-drug-formulary",
+      "description": "API-based data exchange to Third-Party Applications via Member-authorized sharing of Health Plan's Prescription Drug Formulary.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/davinci-drug-formulary/history.html",
+      "canonical": "http://hl7.org/fhir/us/davinci-drug-formulary",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/HL7/davinci-pdex-formulary",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "financials": true,
+        "medsMgmt": true,
+        "profiles": 5,
+        "extensions": 11,
+        "valuesets": 10,
+        "codeSystems": 8,
+        "examples": 22
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.davinci-drug-formulary#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-drug-formulary/STU2.1"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.1",
+          "package": "hl7.fhir.us.davinci-drug-formulary#2.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-drug-formulary/STU2.0.1"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.davinci-drug-formulary#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-drug-formulary/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.davinci-drug-formulary#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-drug-formulary/STU1.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.1",
+          "package": "hl7.fhir.us.davinci-drug-formulary#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-drug-formulary/STU1.0.1"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.davinci-drug-formulary#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/davinci-drug-formulary/STU1"
+        }
+      ]
+    },
+    {
+      "name": "US HAI",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.hai",
+      "description": "Specifies standards for electronic submission of Healthcare Associated Infection (HAI) reports to the National Healthcare Safety Network (NHSN) of the Centers for Disease Control and Prevention (CDC)",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/hai/history.html",
+      "canonical": "http://hl7.org/fhir/us/hai",
+      "ci-build": "http://build.fhir.org/ig/HL7/HAI",
+      "analysis": {
+        "content": true,
+        "questionnaire": true,
+        "profiles": 4,
+        "valuesets": 15,
+        "codeSystems": 2
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.hai#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/hai/STU2.1"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.hai#2.0.0",
+          "fhir-version": [
+            "4.0.0"
+          ],
+          "url": "http://hl7.org/fhir/us/hai/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.hai#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/hai/STU1"
+        }
+      ]
+    },
+    {
+      "name": "US HR1 Medicaid Work Requirements IG (proposed, not supported by CMS)",
+      "npm-name": "cori.fhir.ig.wrig",
+      "category": "Care Management",
+      "description": "Profiles and implementation details for US HR1 Medicaid Work Requirements exemption and activity verification.",
+      "authority": "Cori System Organization",
+      "country": "us",
+      "history": "https://wrig.corisystem.org",
+      "ci-build": "https://build.fhir.org/ig/arosearose3/wrig",
+      "editions": [
+        {
+          "name": "0.1.0",
+          "ig-version": "0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "package": "cori.fhir.ig.wrig#0.1.0",
+          "url": "https://wrig.corisystem.org"
+        }
+      ]
+    },
+    {
+      "name": "US Lab",
+      "category": "Diagnostics",
+      "npm-name": "hl7.fhir.us.lab",
+      "description": "US Realm Laboratory ordering and reporting between ambulatory care setting and the laboratory and laboratory reporting to public health jurisdictions",
+      "authority": "HL7",
+      "product": [
+        "fhir"
+      ],
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "editions": [
+        {
+          "name": "DSTU2",
+          "ig-version": "n/a",
+          "package": "hl7.fhir.us.lab#n/a",
+          "fhir-version": [
+            "1.0.2"
+          ],
+          "url": "http://hl7.org/fhir/DSTU2/uslab/uslab.html"
+        }
+      ],
+      "analysis": {
+        "error": "Unable to resolve package id hl7.fhir.us.lab#n/a"
+      }
+    },
+    {
+      "name": "US Medication REMS",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.medication-rems",
+      "description": "A Risk Evaluation and Mitigation Strategies (REMS) is a drug safety program that the U.S. FDA requires for certain medications with serious safety concerns. Complying with REMS can introduce manual work for the provider and potential delays in getting the medication to the patient. This IG provides guidance on using FHIR to automate notifications and information exchange between the provider and the REMS Administrator--to reduce burden on the provider and prevent delays in patient care.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/medication-rems/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/medication-rems",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-medication-rems-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.medication-rems#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/medication-rems/STU2"
+        }
+      ]
+    },
+    {
+      "name": "US Meds Maturity Project",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.meds",
+      "description": "US Meds Maturity Project: promote consistent use of the FHIR pharmacy resources in the US Realm",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/meds/history.html",
+      "canonical": "http://hl7.org/fhir/us/meds",
+      "ci-build": "http://build.fhir.org/ig/HL7/FHIR-ONC-Meds",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "medsMgmt": true,
+        "profiles": 2
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "1.2.0",
+          "package": "hl7.fhir.us.meds#1.2.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/meds/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.meds#1.0.0",
+          "fhir-version": [
+            "3.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/meds/STU1"
+        }
+      ]
+    },
+    {
+      "name": "US Patient Care Summary (US-PCS) Implementation Guide",
+      "category": "Patient Summary",
+      "npm-name": "hl7.fhir.us.pcs",
+      "description": "The United States Patient Care Summary (US-PCS) is a FHIR document that captures key information for care transitions. It aligns with work from the FHIR International Patient Summary and is intended as a modern, streamlined summary that builds on the long-standing exchange of clinical documents in the United States using the Consolidated Clinical Document Architecture (C-CDA) and specifically the Continuity of Care Document (CCD).",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pcs/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pcs",
+      "ci-build": "http://build.fhir.org/ig/HL7/us-fhir-ps",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.us.pcs#1.0.0-ballot",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pcs/2026May"
+        }
+      ]
+    },
+    {
+      "name": "US Prescription Drug Monitoring Program (PDMP)",
+      "category": "Medications / Immunizations",
+      "npm-name": "hl7.fhir.us.pdmp",
+      "description": "Guidance on the use of FHIR resources and search operations to allow requestors (prescribers, pharmacists, others) to obtain a patient's medication records held in one or more Prescription Drug Monitoring Programs (PDMPs).  Also describes how the information supplied by the PDMPs is contained in the other information exchanges in the larger PDMP environment.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/pdmp/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/pdmp",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-pdmp",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.pdmp#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/pdmp/STU1"
+        }
+      ]
+    },
+    {
+      "name": "US Public Health Profiles Library",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.ph-library",
+      "description": "The US Public Health Profiles Library is a collection of reusable architecture and content profiles representing common public health concepts and patterns. It provides a framework for inclusion in multiple use case specific implementation guides focused on the exchange of Public Health information.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/ph-library/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/ph-library",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-us-ph-library",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.ph-library#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/ph-library/STU2"
+        }
+      ]
+    },
+    {
+      "name": "US Situational Awareness Framework for Reporting (US SAFR) Implementation Guide",
+      "category": "Public Health",
+      "npm-name": "hl7.fhir.us.safr",
+      "description": "Situational Awareness Framework for Reporting (US SAFR)",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/safr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/safr",
+      "ci-build": "http://build.fhir.org/ig/HL7/us-safr",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.safr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/safr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "US Standardized Medication Profile (SMP)",
+      "category": "Medications ",
+      "npm-name": "hl7.fhir.us.smp",
+      "description": "Standardized Medication Profile",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/smp/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/smp",
+      "ci-build": "http://build.fhir.org/ig/HL7/smp",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.smp#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/smp/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Using CQL with FHIR Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "hl7.fhir.uv.cql",
+      "description": "The Using CQL with FHIR implementation guide defines profiles, operations and guidance for the use of CQL with FHIR, both as a mechanism for querying, as well as inline and integrated usage as part of knowledge artifacts.",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/cql/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/cql",
+      "ci-build": "http://build.fhir.org/ig/HL7/cql-ig",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.uv.cql#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/cql/STU2"
+        }
+      ]
+    },
+    {
+      "name": "UZ Core",
+      "category": "National Base",
+      "npm-name": "uz.dhp.core",
+      "description": "National implementation guide for Uzbekistan using FHIR R5",
+      "authority": "MOH Uzbekistan",
+      "product": [
+        "fhir"
+      ],
+      "country": "uz",
+      "language": [
+        "en",
+        "ru",
+        "uz"
+      ],
+      "canonical": "https://dhp.uz/fhir/core"
+    },
+    {
+      "name": "Validated Healthcare Directory",
+      "category": "Administration",
+      "npm-name": "hl7.fhir.uv.vhdir",
+      "description": "Defines the minimum conformance requirements for accessing or exposing validated healthcare directory data and provides a specification for the exchange of directory data between a source of validated provider data and local workflow environments (e.g. local directories)",
+      "authority": "HL7",
+      "country": "uv",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/uv/vhdir/history.html",
+      "canonical": "http://hl7.org/fhir/uv/vhdir",
+      "ci-build": "http://build.fhir.org/ig/HL7/VhDir",
+      "analysis": {},
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.uv.vhdir#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/uv/vhdir/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Vital Records Birth and Fetal Death Reporting",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.bfdr",
+      "description": "Provides guidance to implementers and states on reporting birth and fetal death information based on the current revisions of the U.S. Standard Certificate of Live Birth and U.S. Standard Report of Fetal Death.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/bfdr/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/bfdr",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "documents": true,
+        "clinicalCore": true,
+        "financials": true,
+        "profiles": 49,
+        "extensions": 6,
+        "valuesets": 1,
+        "examples": 137
+      },
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-bfdr",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.bfdr#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/bfdr/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.bfdr#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/bfdr/STU1.1"
+        },
+        {
+          "name": "STU 1 on FHIR R4",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.bfdr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/bfdr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Vital Records Common Profile Library",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.vr-common-library",
+      "description": "Library containing profiles used by other Vital Records IGs such as Birth and Fetal Death Reporting and Birth Defects Reporting.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/vr-common-library/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/us/vr-common-library",
+      "ci-build": "http://build.fhir.org/ig/HL7/vr-common-library",
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 30,
+        "extensions": 4,
+        "valuesets": 5,
+        "examples": 35
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.vr-common-library#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vr-common-library/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.1.0",
+          "package": "hl7.fhir.us.vr-common-library#1.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vr-common-library/STU1.1"
+        },
+        {
+          "name": "STU 1 on FHIR R4",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.vr-common-library#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vr-common-library/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Vital Records Mortality and Morbidity Reporting FHIR IG",
+      "category": "Medication / Immunization",
+      "npm-name": "hl7.fhir.us.vrdr",
+      "description": "The VRDR FHIR IG provides guidance regarding the use of FHIR resources for the bidirectional exchange of mortality data between State-run PHA Vital Records offices and NCHS",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/vrdr/history.html",
+      "canonical": "http://hl7.org/fhir/us/vrdr",
+      "ci-build": "http://build.fhir.org/ig/HL7/vrdr",
+      "analysis": {
+        "content": true,
+        "documents": true,
+        "clinicalCore": true,
+        "profiles": 34,
+        "extensions": 4,
+        "examples": 34
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU3",
+          "ig-version": "3.0.0",
+          "package": "hl7.fhir.us.vrdr#3.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vrdr/STU3"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.2.0",
+          "package": "hl7.fhir.us.vrdr#2.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vrdr/STU2.2"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.1.0",
+          "package": "hl7.fhir.us.vrdr#2.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vrdr/STU2.1"
+        },
+        {
+          "name": "STU 2",
+          "ig-version": "2.0.0",
+          "package": "hl7.fhir.us.vrdr#2.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vrdr/STU2"
+        },
+        {
+          "name": "STU 1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.vrdr#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vrdr/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Vital Signs FHIR IG",
+      "category": "Clinical Observations",
+      "npm-name": "hl7.fhir.us.vitals",
+      "description": "US Realm Implementation Guide for Vital Signs observations with extensions for qualifying data.",
+      "authority": "HL7",
+      "country": "us",
+      "history": "http://hl7.org/fhir/us/vitals/history.html",
+      "canonical": "http://hl7.org/fhir/us/vitals",
+      "ci-build": "http://build.fhir.org/ig/HL7/cimi-vital-signs",
+      "language": [
+        "en"
+      ],
+      "analysis": {
+        "content": true,
+        "clinicalCore": true,
+        "profiles": 15,
+        "extensions": 11,
+        "valuesets": 27,
+        "codeSystems": 3,
+        "examples": 15
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU1",
+          "ig-version": "1.0.0",
+          "package": "hl7.fhir.us.vitals#1.0.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/vitals/STU1"
+        }
+      ]
+    },
+    {
+      "name": "Vulcan FHIR to OMOP FHIR Implementation Guide",
+      "category": "research",
+      "npm-name": "hl7.fhir.uv.omop",
+      "description": "This IG delivers FHIR\u2011to\u2011OMOP Logical Models, StructureMaps, and pragmatic, hands\u2011on implementer guidance, enabling you to: Transform data uniformly with minimal information loss, Accelerate observational research and real\u2011world\u2011evidence generation with FHIR, and Cut costs and time through faster, more consistent ETL pipelines",
+      "authority": "HL7",
+      "country": "uv",
+      "history": "http://hl7.org/fhir/uv/omop/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.org/fhir/uv/omop",
+      "ci-build": "http://build.fhir.org/ig/HL7/fhir-omop",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "INFORMATIVE 1 Ballot",
+          "ig-version": "1.0.0-ballot",
+          "package": "hl7.fhir.uv.omop#1.0.0-ballot",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "http://hl7.org/fhir/uv/omop/2025Sep"
+        }
+      ]
+    },
+    {
+      "name": "WHO Digital Documentation of COVID-19 Certificates (DDCC)",
+      "category": "SMART (WHO)",
+      "npm-name": "who.ddcc",
+      "description": "This WHO Digital Documentation of COVID-19 Certificates (DDCC) Implementation Guide details how to use Health Level 7 (HL7) Fast Healthcare Interoperability Resources (FHIR) for consistent digital representation of COVID-19 certificates and interoperability",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/ddcc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/ddcc",
+      "ci-build": "http://worldhealthorganization.github.io/ddcc",
+      "editions": [
+        {
+          "name": "releases Draft",
+          "ig-version": "1.0.1",
+          "package": "who.ddcc#1.0.1",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/ddcc/1.0.1"
+        }
+      ],
+      "product": [
+        "fhir"
+      ]
+    },
+    {
+      "name": "WHO SMART Guidelines - ANC",
+      "category": "SMART (WHO)",
+      "npm-name": "smart.who.int.anc",
+      "description": "SMART Guidelines for Antenatal Care (ANC)",
+      "authority": "World Health Organization",
+      "country": "uv",
+      "history": "http://smart.who.int/anc/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://smart.who.int/anc",
+      "ci-build": "http://worldhealthorganization.github.io/smart-anc",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Releases",
+          "ig-version": "0.3.0",
+          "package": "smart.who.int.anc#0.3.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://smart.who.int/anc/v0.3.0"
+        }
+      ]
+    },
+    {
+      "name": "WOF Connect Implementation Guide",
+      "category": "Infrastructure",
+      "npm-name": "servicewell.fhir.wof-connect",
+      "description": "Well On FHIR (WOF) is Service Well AB\u2019s initiative to provide shared FHIR APIs for healthcare. This wof.connect Implementation Guide defines the WOF Connect API and is part of a growing family of WOF IGs, including a forthcoming platform-level FHIR API (wof.platform) and other Service Well-authored guides.",
+      "authority": "Service Well",
+      "country": "uv",
+      "history": "http://canonical.fhir.link/servicewell/wof-connect/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://canonical.fhir.link/servicewell/wof-connect",
+      "ci-build": "http://build.fhir.org/ig/servicewell/servicewell.fhir.wof-connect",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Pre-Release Draft",
+          "ig-version": "0.1.0",
+          "package": "servicewell.fhir.wof-connect#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://canonical.fhir.link/servicewell/wof-connect/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "Womens Health Technology Coordinated Registry Network FHIR IG",
+      "category": "Clinical Registries",
+      "npm-name": "hl7.fhir.us.womens-health-registries",
+      "description": "The purpose of the IG to provide the necessary guidance to use FHIR to build registries specific to monitoring Womens Health",
+      "authority": "HL7",
+      "country": "us",
+      "language": [
+        "en"
+      ],
+      "history": "http://hl7.org/fhir/us/womens-health-registries/history.html",
+      "canonical": "http://hl7.org/fhir/us/womens-health-registries",
+      "ci-build": "http://build.fhir.org/ig/HL7/coordinated-registry-network",
+      "analysis": {
+        "content": true,
+        "rest": true,
+        "clinicalCore": true,
+        "profiles": 3
+      },
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Withdrawn",
+          "ig-version": "0.2.0-withdrawal",
+          "package": "hl7.fhir.us.womens-health-registries#0.2.0-withdrawal",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.org/fhir/us/womens-health-registries/0.2.0-withdrawal"
+        }
+      ]
+    },
+    {
+      "name": "xShare Project xShare Project IPS+ Implementation Guide",
+      "category": "EHDS",
+      "npm-name": "hl7.eu.fhir.xshare-ips-plus",
+      "description": "This guide provides instructions to help you understand and implement your product in accordance with the xShare IPS+, facilitating in the access and adoption of the selected specifications.",
+      "authority": "xShare project",
+      "country": "eu",
+      "history": "http://hl7.eu/fhir/ig/xshare-ips-plus/history.html",
+      "language": [
+        "en"
+      ],
+      "canonical": "http://hl7.eu/fhir/ig/xshare-ips-plus",
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/xshare-ips-plus",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "Release 1 Qa-preview",
+          "ig-version": "0.1.0",
+          "package": "hl7.eu.fhir.xshare-ips-plus#0.1.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/ig/xshare-ips-plus/0.1.0"
+        }
+      ]
+    },
+    {
+      "name": "xShare Project Yellow Button Implementation Guide",
+      "category": "EHDS",
+      "npm-name": "hl7.eu.fhir.xshare-yb",
+      "description": "xShare envisions everyone sharing their health data in European Electronic Health Record Exchange Format (EEHRxF) with a click-of-a-button - the xShare yellow button - to be featured across health portals and patient apps, allowing people to exercise their data portability rights under GDPR.",
+      "authority": "xShare project",
+      "country": "eu",
+      "history": "https://hl7.eu/fhir/ig/xshare-yb/history.html",
+      "language": [
+        "en"
+      ],
+      "ci-build": "http://build.fhir.org/ig/hl7-eu/xShare",
+      "canonical": "http://hl7.eu/fhir/ig/xshare-yb",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1.2",
+          "ig-version": "0.2.0",
+          "package": "hl7.eu.fhir.xshare-yb#0.2.0",
+          "fhir-version": [
+            "4.0.1"
+          ],
+          "url": "http://hl7.eu/fhir/ig/xshare-yb/0.2.0"
+        }
+      ]
+    },
+    {
+      "name": "\u00daNICAS Rare Diseases HL7 FHIR Implementation Guide",
+      "category": "Rare Diseases",
+      "npm-name": "unicas-ig",
+      "description": "This is the implementation guide for \u00daNICAS, a project whose objective is to create an ecosystem of partnerships to improve healthcare for pediatric patients with complex rare diseases. Through the network within the National Health System, the project aims to improve the diagnosis and care of patients with rare diseases. Published by TIC Salut Social, CatSalut Departament de Salut de Catalunya, Sistema Nacional de Salud Ministerio de Sanidad de Espa\u00f1a",
+      "authority": "TIC Salut Social",
+      "country": "es",
+      "history": "https://unicas-fhir.sanidad.gob.es/history.html",
+      "language": [
+        "es"
+      ],
+      "canonical": "https://unicas-fhir.sanidad.gob.es",
+      "ci-build": "https://unicas-fhir.sanidad.gob.es",
+      "product": [
+        "fhir"
+      ],
+      "editions": [
+        {
+          "name": "STU 1 Draft",
+          "ig-version": "0.0.1",
+          "package": "unicas-ig#0.0.1",
+          "fhir-version": [
+            "5.0.0"
+          ],
+          "url": "https://unicas-fhir.sanidad.gob.es"
+        }
+      ]
     }
-  },
-  {
-    "name" : "AU Core",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.au.core",
-    "description" : "AU Core implementation guide provides support for the use of FHIR®© in an Australian context, and sets the minimum expectations on FHIR resources to support conformance and implementation in systems.",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "au",
-    "language" : ["en"],
-    "history" : "http://hl7.org.au/fhir/core/history.html",
-    "canonical" : "http://hl7.org.au/fhir/core",
-    "ci-build" : "http://build.fhir.org/ig/hl7au/au-fhir-core",
-    "editions" : [{
-      "name" : "Working Standard",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.au.core#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org.au/fhir/core/2.0.0"
-    }],
-    "analysis" : {
-      "error" : "JsonObject"
-    }
-  },
-  {
-    "name" : "AU Patient Summary",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.fhir.au.ps",
-    "description" : "AU Patient Summary (AU PS) is provided to support the use of patient summaries in FHIR®© in an Australian context. It is based on IPS and AU Core, setting the minimum conformance expectations for implementing support for AU PS documents in systems.",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "au",
-    "language" : ["en"],
-    "history" : "https://hl7.org.au/fhir/ps/history.html",
-    "canonical" : "http://hl7.org.au/fhir/ps",
-    "ci-build" : "https://build.fhir.org/ig/hl7au/au-fhir-ps",
-    "editions" : [{
-      "name" : "Ballot for Working Standard",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.au.ps#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.org.au/fhir/ps/1.0.0-ballot"
-    }],
-    "analysis" : {
-      "error" : "JsonObject"
-    }
-  },
-  {
-    "name" : "AU eRequesting",
-    "category" : "eRequesting",
-    "npm-name" : "hl7.fhir.au.ereq",
-    "description" : "AU eRequesting is provided to support the use of HL7® FHIR®© for diagnostic requesting in an Australian context, and sets the minimum expectations on FHIR resources to support conformance and implementation in systems.",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "au",
-    "language" : ["en"],
-    "history" : "https://hl7.org.au/fhir/ereq/history.html",
-    "canonical" : "http://hl7.org.au/fhir/ereq",
-    "ci-build" : "https://build.fhir.org/ig/hl7au/au-fhir-erequesting",
-    "editions" : [{
-      "name" : "Working Standard",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.au.ereq#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.org.au/fhir/ereq/1.0.0"
-    }],
-    "analysis" : {
-      "error" : "JsonObject"
-    }
-  },
-  {
-    "name" : "NZ Base",
-    "category" : "National Base",
-    "npm-name" : "fhir.org.nz.ig.base",
-    "description" : "Base New Zealand national implementation guide",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "nz",
-    "language" : ["en"],
-    "canonical" : "http://fhir.org.nz/ig/base",
-    "history" : "https://fhir.org.nz/ig/base/package-list.json",
-    "ci-build" : "http://build.fhir.org/ig/HL7NZ/nzbase/branches/master/index.html",
-    "editions" : [{
-      "name" : "Release 3",
-      "ig-version" : "3.0.0",
-      "package" : "fhir.org.nz.ig.base#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.org.nz/ig/base"
-    }],
-    "analysis" : {
-      "error" : "Error fetching package directly (http://fhir.org.nz/ig/base/1.0.0/package.tgz), or fetching package list for fhir.org.nz.ig.base from http://fhir.org.nz/ig/base/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://fhir.org.nz/ig/base/1.0.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-6.log)"
-    }
-  },
-  {
-    "name" : "UZ Core",
-    "category" : "National Base",
-    "npm-name" : "uz.dhp.core",
-    "description" : "National implementation guide for Uzbekistan using FHIR R5",
-    "authority" : "MOH Uzbekistan",
-    "product" : ["fhir"],
-    "country" : "uz",
-    "language" : ["en", "ru", "uz"],
-    "canonical" : "https://dhp.uz/fhir/core"
-  },
-  {
-    "name" : "CCDA on FHIR",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.fhir.us.ccda",
-    "description" : "US Realm Implementation Guide (IG) addressing the key aspects of Consolidated CDA (C-CDA) required for Meaningful Use (MU). This IG focuses on the clinical document header and narrative constraints necessary for human readability, and references the Data Access Framework (DAF) implementation guide for coded data representation",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/ccda/history.html",
-    "canonical" : "http://hl7.org/fhir/us/ccda",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ccda-on-fhir",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "profiles" : 12,
-      "extensions" : 8,
-      "valuesets" : 10,
-      "examples" : 32
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.ccda#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ccda/2025Jan"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.2.0",
-      "package" : "hl7.fhir.us.ccda#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ccda/STU1.2"
-    },
-    {
-      "name" : "STU 1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.ccda#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ccda/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.ccda#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/ccda/STU1"
-    }]
-  },
-  {
-    "name" : "SDC (Structured Data Capture)",
-    "category" : "Forms Management",
-    "npm-name" : "hl7.fhir.uv.sdc",
-    "description" : "Defines expectations for sharing of Questionnaires and answers, including mechanisms for automatically populating portions of a questionnaire based on embedded mappings to underlying data elements",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/sdc/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/sdc",
-    "ci-build" : "http://build.fhir.org/ig/HL7/sdc",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "questionnaire" : true,
-      "profiles" : 26,
-      "extensions" : 42,
-      "logicals" : 2,
-      "operations" : 7,
-      "valuesets" : 9,
-      "codeSystems" : 7,
-      "examples" : 48
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 4",
-      "ig-version" : "4.0.0",
-      "package" : "hl7.fhir.uv.sdc#4.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/sdc/STU4"
-    }]
-  },
-  {
-    "name" : "SDC Data Elements Registry",
-    "category" : "Forms Management",
-    "npm-name" : "hl7.fhir.us.sdcde",
-    "description" : "Defines expectations for sharing of data elements between registries",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/sdcde/history.html",
-    "canonical" : "http://hl7.org/fhir/us/sdcde",
-    "ci-build" : "http://build.fhir.org/ig/HL7/sdc-de",
-    "analysis" : {
-      "error" : "Unable to resolve package id hl7.fhir.us.sdcde#1.0.2"
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0",
-      "package" : "hl7.fhir.us.sdcde#2.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/sdcde/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.2",
-      "package" : "hl7.fhir.us.sdcde#1.0.2",
-      "fhir-version" : ["1.0.2"],
-      "url" : "http://hl7.org/fhir/DSTU2/sdcde/sdcde.html"
-    }]
-  },
-  {
-    "name" : "US Lab",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.us.lab",
-    "description" : "US Realm Laboratory ordering and reporting between ambulatory care setting and the laboratory and laboratory reporting to public health jurisdictions",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "editions" : [{
-      "name" : "DSTU2",
-      "ig-version" : "n/a",
-      "package" : "hl7.fhir.us.lab#n/a",
-      "fhir-version" : ["1.0.2"],
-      "url" : "http://hl7.org/fhir/DSTU2/uslab/uslab.html"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id hl7.fhir.us.lab#n/a"
-    }
-  },
-  {
-    "name" : "DAF",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.us.daf",
-    "description" : "Basic arrangements for accessing meaningful use data from EHR systems **NOTE: DAF has been superseded by Argonaut, DAF-Research and US-Core**",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/daf/history.html",
-    "canonical" : "http://hl7.org/fhir/us/daf",
-    "ci-build" : "http://build.fhir.org/ig/HL7/daf-research",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 5,
-      "extensions" : 2,
-      "operations" : 3,
-      "valuesets" : 2,
-      "codeSystems" : 2
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.daf#2.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/daf-research/STU2"
-    },
-    {
-      "name" : "DSTU 1",
-      "ig-version" : "1.0.2",
-      "package" : "hl7.fhir.us.daf#1.0.2",
-      "fhir-version" : ["1.0.2"],
-      "url" : "http://hl7.org/fhir/DSTU2/daf/daf.html"
-    }]
-  },
-  {
-    "name" : "Argonaut Data Query",
-    "category" : "EHR Access",
-    "npm-name" : "fhir.argonaut.r2",
-    "description" : "This implementation guide is based upon DSTU2 FHIR standard and covers the US EHR data access for the ONC Common Clinical Data Set and retrieval of static documents",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://www.fhir.org/guides/argonaut/r2/history.html",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/data-query",
-    "canonical" : "http://fhir.org/guides/argonaut/r2",
-    "editions" : [{
-      "name" : "First Release",
-      "ig-version" : "1.0.0",
-      "package" : "fhir.argonaut.r2#1.0.0",
-      "fhir-version" : ["1.0.2"],
-      "url" : "http://fhir.org/guides/argonaut/r2/1.0"
-    }],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 17,
-      "extensions" : 5,
-      "operations" : 1,
-      "valuesets" : 25
-    }
-  },
-  {
-    "name" : "HSPC EHR Guide",
-    "category" : "EHR Access",
-    "npm-name" : "fhir.hspc.core",
-    "description" : "Builds on Argonaut to make agreements around consistent data (in progress)",
-    "authority" : "HSPC (USA)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://fhir.org/guides/hspc/core/history.html",
-    "canonical" : "http://fhir.org/guides/hspc/core",
-    "ci-build" : "http://build.fhir.org/ig/hspc/core",
-    "editions" : [],
-    "analysis" : {
-    }
-  },
-  {
-    "name" : "US Meds Maturity Project",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.meds",
-    "description" : "US Meds Maturity Project: promote consistent use of the FHIR pharmacy resources in the US Realm",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/meds/history.html",
-    "canonical" : "http://hl7.org/fhir/us/meds",
-    "ci-build" : "http://build.fhir.org/ig/HL7/FHIR-ONC-Meds",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 2
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "1.2.0",
-      "package" : "hl7.fhir.us.meds#1.2.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/meds/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.meds#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/meds/STU1"
-    }]
-  },
-  {
-    "name" : "QICore",
-    "category" : "Quality / CDS",
-    "npm-name" : "hl7.fhir.us.qicore",
-    "description" : "QICore defines a uniform way for quality measurement and decision support knowledge to refer to clinical data. The profiles align as much as possible with DAF and incorporate content from the (Quality Data Model) and the (Virtual Medical Record) specifications",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/qicore/history.html",
-    "canonical" : "http://hl7.org/fhir/us/qicore",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-qi-core",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "profiles" : 51,
-      "extensions" : 8,
-      "valuesets" : 21,
-      "codeSystems" : 5,
-      "examples" : 66
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 7",
-      "ig-version" : "7.0.2",
-      "package" : "hl7.fhir.us.qicore#7.0.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/qicore/STU7.0.2"
-    }]
-  },
-  {
-    "name" : "DAF-Research",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.us.daf-research",
-    "description" : "DAF-Research IG focuses on enabling researchers to access data from multiple organizations",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/daf/history.html",
-    "canonical" : "http://hl7.org/fhir/us/daf",
-    "ci-build" : "http://build.fhir.org/ig/HL7/daf-research",
-    "editions" : [{
-      "name" : "STU",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.daf-research#2.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/daf-research"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id hl7.fhir.us.daf-research#2.0.0"
-    }
-  },
-  {
-    "name" : "US HAI",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.hai",
-    "description" : "Specifies standards for electronic submission of Healthcare Associated Infection (HAI) reports to the National Healthcare Safety Network (NHSN) of the Centers for Disease Control and Prevention (CDC)",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/hai/history.html",
-    "canonical" : "http://hl7.org/fhir/us/hai",
-    "ci-build" : "http://build.fhir.org/ig/HL7/HAI",
-    "analysis" : {
-      "content" : true,
-      "questionnaire" : true,
-      "profiles" : 4,
-      "valuesets" : 15,
-      "codeSystems" : 2
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.hai#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/hai/STU2.1"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.hai#2.0.0",
-      "fhir-version" : ["4.0.0"],
-      "url" : "http://hl7.org/fhir/us/hai/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.hai#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/hai/STU1"
-    }]
-  },
-  {
-    "name" : "US Breast Cancer Data",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.us.breastcancer",
-    "description" : "Logical models and FHIR profiles for supporting breast cancer staging estimation, including the traditional three-component staging involving primary tumor classification, regional lymph nodes and distant metastases, as well as other factors important to prognosis and recurrence risk, such as tumor grade, hormone receptor status (progesterone and estrogen), as well as human epidermal growth factor 2 (HER 2) status",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/breastcancer/history.html",
-    "canonical" : "http://hl7.org/fhir/us/breastcancer",
-    "ci-build" : "http://build.fhir.org/ig/HL7/us-breastcancer",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "profiles" : 57,
-      "extensions" : 46,
-      "logicals" : 260,
-      "valuesets" : 35,
-      "codeSystems" : 9
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Draft",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.us.breastcancer#0.2.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/breastcancer/2018Sep"
-    }]
-  },
-  {
-    "name" : "Genomics Reporting",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.genomics-reporting",
-    "description" : "This implementation guide tries to provide guidance that will enable improved interoperable and computable sharing of genetic testing results",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/genomics-reporting/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/genomics-reporting",
-    "ci-build" : "http://build.fhir.org/ig/HL7/genomics-reporting",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 18,
-      "extensions" : 4,
-      "operations" : 1,
-      "valuesets" : 10,
-      "codeSystems" : 3,
-      "examples" : 65
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU3",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.uv.genomics-reporting#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/genomics-reporting/STU3"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.uv.genomics-reporting#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/genomics-reporting/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.genomics-reporting#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/genomics-reporting/STU1"
-    }]
-  },
-  {
-    "name" : "Argonaut Provider Directory",
-    "category" : "Administration",
-    "npm-name" : "fhir.argonaut.pd",
-    "description" : "This implementation guide is based upon STU3 FHIR standard and outlines the key data elements for any provider directory and basic query guidance. The components developed in this guide are intended to provide a foundation for a central or distributed Provider or Healthcare Directory",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://www.fhir.org/guides/argonaut/pd/history.html",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/provider-directory",
-    "canonical" : "http://fhir.org/guides/argonaut/pd",
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0",
-      "package" : "fhir.argonaut.pd#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.org/guides/argonaut/pd/release1"
-    }],
-    "analysis" : {
-      "error" : "Unknown FHIRVersion code 'STU3'"
-    }
-  },
-  {
-    "name" : "Argonaut Scheduling",
-    "category" : "Administration",
-    "npm-name" : "fhir.argonaut.scheduling",
-    "description" : "This implementation guide is based upon STU3 FHIR standard and provides FHIR RESTful APIs and guidance for access to and booking of appointments for patients by both patient and practitioner end users",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://www.fhir.org/guides/argonaut/scheduling/history.html",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/scheduling",
-    "canonical" : "http://fhir.org/guides/argonaut/scheduling",
-    "editions" : [{
-      "name" : "First Release",
-      "ig-version" : "1.0.0",
-      "package" : "fhir.argonaut.scheduling#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.org/guides/argonaut/scheduling/release1"
-    }],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "financials" : true,
-      "scheduling" : true,
-      "profiles" : 7,
-      "extensions" : 4,
-      "operations" : 4,
-      "valuesets" : 7,
-      "codeSystems" : 3
-    }
-  },
-  {
-    "name" : "International Patient Summary",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.fhir.uv.ips",
-    "description" : "The International Patient Summary (IPS) is a minimal and non-exhaustive patient summary, specialty-agnostic, condition-independent, but readily usable by clinicians for the cross-border unscheduled care of a patient",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/ips/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/ips",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-ips",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "profiles" : 33,
-      "extensions" : 1,
-      "valuesets" : 44,
-      "codeSystems" : 1,
-      "examples" : 33
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.uv.ips#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/ips/STU2"
-    }]
-  },
-  {
-    "name" : "IHE Patient Demographics Query for Mobile (PDQm)",
-    "category" : "Administration",
-    "npm-name" : "ihe.iti.pdqm",
-    "description" : "Defines a lightweight RESTful interface to a patient demographics supplier leveraging technologies readily available to mobile applications and lightweight browser based applications",
-    "authority" : "IHE",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://profiles.ihe.net/ITI/PDQm/history.html",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.PDQm/branches/main",
-    "canonical" : "https://profiles.ihe.net/ITI/PDQm",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 3,
-      "examples" : 4
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "3.2.0",
-      "package" : "ihe.iti.pdqm#3.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/PDQm/3.2.0"
-    }]
-  },
-  {
-    "name" : "IHE Patient Identifier Cross-referencing for Mobile (PIXm)",
-    "category" : "Administration",
-    "npm-name" : "ihe.iti.pixm",
-    "description" : "Defines a lightweight RESTful interface to a Patient Identifier Cross-reference Manager, leveraging technologies readily available to mobile applications and lightweight browser based applications",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/PIXm/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/PIXm",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.PIXm",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 8,
-      "operations" : 1,
-      "examples" : 17
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "3.1.0",
-      "package" : "ihe.iti.pixm#3.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/PIXm/3.1.0"
-    }]
-  },
-  {
-    "name" : "IHE Patient Master Identity Registry (PMIR)",
-    "category" : "Administration",
-    "npm-name" : "ihe.iti.pmir",
-    "description" : "Supports the creating, updating and deprecating of patient master identity information about a subject of care, as well as subscribing to these changes, using the HL7 FHIR standard and its RESTful transactions. In PMIR, “patient identity” information includes all information found in the FHIR Patient Resource such as identifier, name, phone, gender, birth date, address, marital status, photo, others to contact, preference for language, general practitioner, and links to other instances of identities. The “patient master identity” is a dominant identity managed centrally among many participating organizations (a.k.a., “Golden Patient Identity”).",
-    "authority" : "IHE",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "https://profiles.ihe.net/ITI/PMIR/history.html",
-    "analysis" : {
-      "error" : "Error fetching package directly (https://profiles.ihe.net/ITI/PMIR/0.1.0/package.tgz), or fetching package list for ihe.iti.pmir from https://profiles.ihe.net/ITI/PMIR/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/ITI/PMIR/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-23.log)"
-    },
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.PMIR/branches/master/index.html",
-    "canonical" : "https://profiles.ihe.net/ITI/PMIR",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.6.0",
-      "package" : "ihe.iti.pmir#1.6.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/PMIR/1.6.0"
-    }]
-  },
-  {
-    "name" : "IHE FHIR AuditEvent query and feed to ATNA",
-    "category" : "Privacy / Security",
-    "npm-name" : "ihe.iti.atna",
-    "description" : "Enable audit log recording (feed) and access to ATNA Audit Repository queries using FHIR AuditEvent resource",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "https://wiki.ihe.net/index.php/Audit_Trail_and_Node_Authentication",
-    "canonical" : "https://wiki.ihe.net/index.php/Audit_Trail_and_Node_Authentication",
-    "editions" : [{
-      "name" : "R4 Trial-Implementation",
-      "ig-version" : "0.2.0",
-      "package" : "ihe.iti.atna#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://wiki.ihe.net/index.php/Audit_Trail_and_Node_Authentication"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.iti.atna#0.2.0"
-    }
-  },
-  {
-    "name" : "IHE Mobile Alert Communication Management(mACM)",
-    "category" : "Communications",
-    "npm-name" : "ihe.iti.macm",
-    "description" : "Provides the infrastructural components needed to send short, unstructured text alerts to human recipients and can record the outcomes of any human interactions upon receipt of the alert. ",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Mobile_Alert_Communication_Management(mACM)",
-    "canonical" : "http://wiki.ihe.net/index.php/Mobile_Alert_Communication_Management(mACM)",
-    "editions" : [{
-      "name" : "R4 Trial-Implementation",
-      "ig-version" : "0.2.0",
-      "package" : "ihe.iti.macm#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Mobile_Alert_Communication_Management(mACM)"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.iti.macm#0.2.0"
-    }
-  },
-  {
-    "name" : "IHE Mobile Cross-Enterprise Document Data Element Extraction (mXDE)",
-    "category" : "Clinical Documents",
-    "npm-name" : "ihe.iti.mxde",
-    "description" : "Provides the means to access data elements extracted from shared structured documents",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Mobile_Cross-Enterprise_Document_Data_Element_Extraction",
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.iti.mxde#0.1.2"
-    },
-    "canonical" : "https://profiles.ihe.net/ITI/mXDE",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.mXDE/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.3.0",
-      "package" : "ihe.iti.mxde#1.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/mXDE/1.3.0"
-    }]
-  },
-  {
-    "name" : "IHE Query for Existing Data for Mobile (QEDm)",
-    "category" : "EHR Access",
-    "npm-name" : "ihe.pcc.qedm",
-    "description" : "Supports queries for clinical data elements, including observations, allergy and intolerances, conditions, diagnostic results, medications, immunizations, procedures, encounters and provenance by making the information widely available to other systems within and across enterprises",
-    "authority" : "IHE",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Query_for_Existing_Data_for_Mobile",
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.qedm#0.2.1"
-    },
-    "canonical" : "https://profiles.ihe.net/PCC/QEDm",
-    "ci-build" : "http://build.fhir.org/ig/IHE/PCC.QEDm/branches/master/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "3.0.0",
-      "package" : "ihe.pcc.qedm#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/PCC/QEDm/3.0.0"
-    }]
-  },
-  {
-    "name" : "IHE Non-Patient File Sharing (NPFS)",
-    "category" : "Administration",
-    "npm-name" : "ihe.iti.npfs",
-    "description" : "Defines how to enable the sharing of non-patient files such as workflow definitions, privacy policies, blank forms, and stylesheets",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Non-patient_File_Sharing_(NPFS)",
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.iti.npfs#0.2.0"
-    },
-    "canonical" : "https://profiles.ihe.net/ITI/NPFS",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.NPFS/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "2.2.0",
-      "package" : "ihe.iti.npfs#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/NPFS/2.2.0"
-    }]
-  },
-  {
-    "name" : "IHE Standardized Operational Log of Events (SOLE)",
-    "category" : "Administration",
-    "npm-name" : "ihe.rad.sole",
-    "description" : "Defines a way to exchange information about events that can then be collected and displayed using standard methods",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Standardized_Operational_Log_of_Events",
-    "canonical" : "http://wiki.ihe.net/index.php/Standardized_Operational_Log_of_Events",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.rad.sole#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Standardized_Operational_Log_of_Events"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.rad.sole#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Mobile Medication Administration (MMA)",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "ihe.pharm.mma",
-    "description" : "Defines the integration between healthcare systems and mobile (or any other) clients using RESTful web services. This allows connecting EHRs with smartphones, smart pill boxes, and other personal or professional devices",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Mobile_Medication_Administration",
-    "canonical" : "http://wiki.ihe.net/index.php/Mobile_Medication_Administration",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pharm.mma#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Mobile_Medication_Administration"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pharm.mma#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Uniform Barcode Processing (UBP)",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "ihe.pharm.ubp",
-    "description" : "Uniform Barcode Processing for Medications",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Uniform_Barcode_Processing",
-    "canonical" : "http://wiki.ihe.net/index.php/Uniform_Barcode_Processing",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pharm.ubp#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Uniform_Barcode_Processing"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pharm.ubp#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Mobile Retrieve Form for Data Capture (mRFD)",
-    "category" : "Forms Management",
-    "npm-name" : "ihe.qrph.mrfd",
-    "description" : "Provides a method for gathering data within a user’s current application to meet the requirements of an external system. mRFD supports RESTful retrieval of forms from a form source, display and completion of a form, and return of instance data from the display application to the source application. The workflows defined in this profile are based on those defined by the Retrieve Form for Data Capture (RFD) profile",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Mobile_Retrieve_Form_for_Data_Capture",
-    "canonical" : "http://wiki.ihe.net/index.php/Mobile_Retrieve_Form_for_Data_Capture",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.qrph.mrfd#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Mobile_Retrieve_Form_for_Data_Capture"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.qrph.mrfd#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Vital Records Death Reporting (VRDR)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "ihe.qrph.vrdr",
-    "description" : "Defines a Retrieve Form for Data Capture (RFD) content profile that will specify derivation of source content from a medical summary document. by defining requirements for form filler content and form manager handling of the content",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Vital_Records_Death_Reporting",
-    "canonical" : "http://wiki.ihe.net/index.php/Vital_Records_Death_Reporting",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.qrph.vrdr#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Vital_Records_Death_Reporting"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.qrph.vrdr#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Dynamic Care Planning (DCP)",
-    "category" : "Care Management",
-    "npm-name" : "ihe.pcc.dcp",
-    "description" : "Provides the structures and transactions for care planning, sharing Care Plans that meet the needs of many, such as providers, patients and payers",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Dynamic_Care_Planning",
-    "canonical" : "http://wiki.ihe.net/index.php/Dynamic_Care_Planning",
-    "editions" : [{
-      "name" : "R4 Trial-Implementation",
-      "ig-version" : "0.2.0",
-      "package" : "ihe.pcc.dcp#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Dynamic_Care_Planning"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.dcp#0.2.0"
-    }
-  },
-  {
-    "name" : "IHE Dynamic Care Team Management (DCTM)",
-    "category" : "Care Management",
-    "npm-name" : "ihe.pcc.dctm",
-    "description" : "Provides the means for sharing care team information about a patient’s care teams that meet the needs of many users, such as providers, patients and payers",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Dynamic_Care_Team_Management",
-    "canonical" : "http://wiki.ihe.net/index.php/Dynamic_Care_Team_Management",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.2.0",
-      "package" : "ihe.pcc.dctm#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Dynamic_Care_Team_Management"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.dctm#0.2.0"
-    }
-  },
-  {
-    "name" : "Point-of-Care Medical Device Tracking (PMDT)",
-    "category" : "Administration",
-    "npm-name" : "ihe.pcc.pmdt",
-    "description" : "provides definition for a mobile Device",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Point-of-Care_Medical_Device_Tracking",
-    "canonical" : "http://wiki.ihe.net/index.php/Point-of-Care_Medical_Device_Tracking",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pcc.pmdt#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Point-of-Care_Medical_Device_Tracking"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.pmdt#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Reconciliation of Clinical Content and Care Providers (RECON)",
-    "category" : "Administration",
-    "npm-name" : "ihe.pcc.recon",
-    "description" : "Provides the ability to communicate lists of clinical data that were reconciled, when they were reconciled and who did the reconciliation using CDA® constructs and FHIR® Resource attributes",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Reconciliation_of_Clinical_Content_and_Care_Providers",
-    "canonical" : "http://wiki.ihe.net/index.php/Reconciliation_of_Clinical_Content_and_Care_Providers",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pcc.recon#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Reconciliation_of_Clinical_Content_and_Care_Providers"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.recon#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Remote Patient Monitoring (RPM)",
-    "category" : "Personal Healthcare",
-    "npm-name" : "ihe.pcc.rpm",
-    "description" : "Provides means of reporting measurements taken by Personal Healthcare Devices in a remote location",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Remote_Patient_Monitoring",
-    "canonical" : "http://wiki.ihe.net/index.php/Remote_Patient_Monitoring",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pcc.rpm#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Remote_Patient_Monitoring"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.rpm#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Routine Interfacility Patient Transport (RIPT)",
-    "category" : "Communications",
-    "npm-name" : "ihe.pcc.ript",
-    "description" : "Provides means of updating a Transport team with critical and necessary medical information on a patient to be transported",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Routine_Interfacility_Patient_Transport",
-    "canonical" : "http://wiki.ihe.net/index.php/Routine_Interfacility_Patient_Transport",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pcc.ript#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Routine_Interfacility_Patient_Transport"
-    }],
-    "analysis" : {
-      "error" : "Error fetching package directly (http://profiles.ihe.net/PCC/RIPT/0.1.0/package.tgz), or fetching package list for ihe.pcc.ript from http://profiles.ihe.net/PCC/RIPT/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/PCC/RIPT/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-73.log)"
-    }
-  },
-  {
-    "name" : "IHE Assessment Curation and Data Collection (ACDC)",
-    "category" : "EHR Access",
-    "npm-name" : "ihe.iti.acdc",
-    "description" : "Enables assessment developers and curators a means by which they can distribute assessment instruments to healthcare providers, supporting exchange of assessment data in a standardized form using the HL7 FHIR Questionnaire resource.",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "https://wiki.ihe.net/index.php/Assessment_Curation_and_Data_Collection",
-    "canonical" : "https://wiki.ihe.net/index.php/Assessment_Curation_and_Data_Collection",
-    "editions" : [{
-      "name" : "R4 Trial-Implementation",
-      "ig-version" : "1.1.0",
-      "package" : "ihe.pcc.acdc#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://wiki.ihe.net/index.php/Assessment_Curation_and_Data_Collection"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.acdc#1.1.0"
-    }
-  },
-  {
-    "name" : "IHE Mobile Aggregate Data Exchange (mADX)",
-    "category" : "EHR Access",
-    "npm-name" : "ihe.qrph.madx",
-    "description" : "Supports interoperable public health reporting of aggregate health data.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "https://wiki.ihe.net/index.php/Mobile_Aggregate_Data_Exchange_(mADX)",
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.qrph.madx#0.1.0"
-    },
-    "canonical" : "https://profiles.ihe.net/QRPH/mADX",
-    "ci-build" : "http://build.fhir.org/ig/IHE/QRPH.mADX/branches/master/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "3.0.0",
-      "package" : "ihe.qrph.madx#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/QRPH/mADX/3.0.0"
-    }]
-  },
-  {
-    "name" : "Electronic Case Reporting",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.ecr",
-    "description" : "The Electronic Case Reporting (eCR) Implementation Guide supports Reporting, investigation, and management via electronic transmission of clinical data from Electronic Health Records to Public Health Agencies, along with the management and processing of population cases. Ths IG covers Bi-directional information exchange and triggering and decision support",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/ecr/history.html",
-    "canonical" : "http://hl7.org/fhir/us/ecr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/case-reporting",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 57,
-      "extensions" : 25,
-      "operations" : 1,
-      "valuesets" : 8,
-      "codeSystems" : 8,
-      "examples" : 94
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 3 Ballot",
-      "ig-version" : "3.0.0-ballot",
-      "package" : "hl7.fhir.us.ecr#3.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ecr/2.1.2"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.ecr#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ecr/2.1.0"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.ecr#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ecr/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.ecr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ecr/STU1"
-    }]
-  },
-  {
-    "name" : "Loinc/IVD Test mapping",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.livd",
-    "description" : "The LIVD Implementation Guide provides a industry standard expression for an IVD device manufacturer's suggestions for a specific device's mapping from the internal, proprietary IVD test codes to suggested LOINC codes when a LIS manager is connecting and configuring a device to the LIS",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/livd/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/livd",
-    "ci-build" : "http://build.fhir.org/ig/HL7/livd",
-    "analysis" : {
-      "content" : true,
-      "diagnostics" : true,
-      "profiles" : 10,
-      "extensions" : 4,
-      "valuesets" : 6,
-      "codeSystems" : 5,
-      "examples" : 8
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.livd#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/livd/2024Jan"
-    }]
-  },
-  {
-    "name" : "Point of Care Devices",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.pocd",
-    "description" : "Defines the use of FHIR resources to convey measurements and supporting data from acute care point-of-care medical devices (PoCD) to receiving systems for electronic medical records, clinical decision support, and medical data archiving for aggregate quality measurement and research purposes",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/pocd/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/pocd",
-    "ci-build" : "http://build.fhir.org/ig/HL7/uv-pocd",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 13,
-      "extensions" : 12,
-      "valuesets" : 8,
-      "codeSystems" : 5,
-      "examples" : 21
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.3.0",
-      "package" : "hl7.fhir.uv.pocd#0.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/pocd/2021Sep"
-    }]
-  },
-  {
-    "name" : "Potential Drug/Drug Interaction",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.uv.pddi",
-    "description" : "This implementation guide is targeted at stakeholders who seek to increase the specificity and clinical relevance of drug-drug interaction alerts presented through the electronic health record. The approach is service-oriented and uses Web standards, a minimum information model for potential drug interactions, and emerging Health Information Technology standards including CDS Hooks, FHIR, and Clinical Quality Language (CQL)",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/pddi/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/pddi",
-    "ci-build" : "http://build.fhir.org/ig/HL7/PDDI-CDS",
-    "analysis" : {
-      "valuesets" : 88,
-      "codeSystems" : 1,
-      "examples" : 36
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.pddi#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/pddi/2023Jan"
-    }]
-  },
-  {
-    "name" : "Validated Healthcare Directory",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.uv.vhdir",
-    "description" : "Defines the minimum conformance requirements for accessing or exposing validated healthcare directory data and provides a specification for the exchange of directory data between a source of validated provider data and local workflow environments (e.g. local directories)",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/vhdir/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/vhdir",
-    "ci-build" : "http://build.fhir.org/ig/HL7/VhDir",
-    "analysis" : {
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.vhdir#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/vhdir/STU1"
-    }]
-  },
-  {
-    "name" : "Coverage Requirements Determination (Da Vinci)",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-crd",
-    "description" : "Provides a mechanism for healthcare providers to discover guidelines, pre-authorization requirements and other expectations from payor organizations related to a proposed medication, procedure or other service associated with a patient's insurance coverage. Supports both patient-specific and patient-independent information retrieval",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/davinci-crd/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-crd",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-crd",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "scheduling" : true,
-      "profiles" : 18,
-      "extensions" : 1,
-      "valuesets" : 8,
-      "codeSystems" : 3,
-      "examples" : 19
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2.2",
-      "ig-version" : "2.2.1",
-      "package" : "hl7.fhir.us.davinci-crd#2.2.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-crd/2.2.1"
-    }]
-  },
-  {
-    "name" : "Data Exchange for Quality Measures (Da Vinci)",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-deqm",
-    "description" : "Provides a mechanism for healthcare providers and data aggregators to exchange quality measure information using subscription, query, and push methods",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/davinci-deqm/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-deqm",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-deqm",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "measures" : true,
-      "profiles" : 11,
-      "extensions" : 8,
-      "operations" : 1,
-      "valuesets" : 2,
-      "codeSystems" : 2,
-      "examples" : 87
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU5 (v5.0.0)",
-      "ig-version" : "5.0.0",
-      "package" : "hl7.fhir.us.davinci-deqm#5.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/STU5"
-    },
-    {
-      "name" : "STU4 (v4.0.0)",
-      "ig-version" : "4.0.0",
-      "package" : "hl7.fhir.us.davinci-deqm#4.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/STU4"
-    },
-    {
-      "name" : "STU 3",
-      "ig-version" : "3.1.0",
-      "package" : "hl7.fhir.us.davinci-deqm#3.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/STU3.1"
-    },
-    {
-      "name" : "STU 3",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.us.davinci-deqm#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/STU3"
-    },
-    {
-      "name" : "STU 3",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.davinci-deqm#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/2020Sep"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.davinci-deqm#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-deqm#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-deqm/STU1"
-    }]
-  },
-  {
-    "name" : "Occupational Data for Health",
-    "category" : "Clinical Observations",
-    "npm-name" : "hl7.fhir.us.odh",
-    "description" : "This IG covers the specific data that covers past or present jobs, usual work, employment status, retirement date and combat zone period for the subject. It also includes the past or present jobs and usual work of other household members",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/odh/history.html",
-    "canonical" : "http://hl7.org/fhir/us/odh",
-    "ci-build" : "http://build.fhir.org/ig/HL7/us-odh",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 6,
-      "extensions" : 2,
-      "valuesets" : 9,
-      "codeSystems" : 1,
-      "examples" : 8
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.3 on FHIR R4",
-      "ig-version" : "1.3.0",
-      "package" : "hl7.fhir.us.odh#1.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/odh/STU1.3"
-    },
-    {
-      "name" : "STU 1.2 on FHIR R4",
-      "ig-version" : "1.2.0",
-      "package" : "hl7.fhir.us.odh#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/odh/STU1.2"
-    },
-    {
-      "name" : "STU 1.1 on FHIR R4",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.odh#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/odh/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.odh#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/odh/STU1"
-    }]
-  },
-  {
-    "name" : "IHE Paramedicine Care Summary (PCS)",
-    "category" : "Communications",
-    "npm-name" : "ihe.pcc.pcs",
-    "description" : "Provides means for Emergency Transport to inform destination Hospital with critical and necessary medical information on patient being transported",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Paramedicine_Care_Summary",
-    "canonical" : "http://wiki.ihe.net/index.php/Paramedicine_Care_Summary",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pcc.pcs#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Paramedicine_Care_Summary"
-    }],
-    "analysis" : {
-      "error" : "Error fetching package directly (https://profiles.ihe.net/PCC/PCS/0.1.0/package.tgz), or fetching package list for ihe.pcc.pcs from https://profiles.ihe.net/PCC/PCS/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/PCC/PCS/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-84.log)"
-    }
-  },
-  {
-    "name" : "IHE Birth and Fetal Death Reporting - Enhanced (BFDE)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "ihe.pcc.bfde",
-    "description" : "Provides means for pre-populating of data from electronic health record systems to electronic vital records systems for birth and fetal death reporting",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Birth_and_Fetal_Death_Reporting_Enhanced_Profile",
-    "canonical" : "http://wiki.ihe.net/index.php/Birth_and_Fetal_Death_Reporting_Enhanced_Profile",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.pcc.bfde#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Birth_and_Fetal_Death_Reporting_Enhanced_Profile"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id ihe.pcc.bfde#0.1.0"
-    }
-  },
-  {
-    "name" : "IHE Quality Outcome Reporting for EMS (QORE)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "ihe.qrph.qore",
-    "description" : "Supports transmission of clinical data for use in calculating Emergency Medical Services Quality measures. Focus on Stroke, CPR, and STEMI",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://wiki.ihe.net/index.php/Quality_Outcome_Reporting_for_EMS",
-    "canonical" : "http://wiki.ihe.net/index.php/Quality_Outcome_Reporting_for_EMS",
-    "editions" : [{
-      "name" : "STU3 Trial-Implementation",
-      "ig-version" : "0.1.0",
-      "package" : "ihe.qrph.qore#0.1.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://wiki.ihe.net/index.php/Quality_Outcome_Reporting_for_EMS"
-    }],
-    "analysis" : {
-      "error" : "Error fetching package directly (http://profiles.ihe.net/QRPH/QORE/0.1.0/package.tgz), or fetching package list for ihe.qrph.qore from http://profiles.ihe.net/QRPH/QORE/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://profiles.ihe.net/QRPH/QORE/0.1.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-92.log)"
-    }
-  },
-  {
-    "name" : "Smart App Launch Implementation Guide",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.uv.smart-app-launch",
-    "description" : "App access to Healthcare software",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/smart-app-launch/history.html",
-    "canonical" : "http://hl7.org/fhir/smart-app-launch",
-    "ci-build" : "http://build.fhir.org/ig/HL7/smart-app-launch",
-    "analysis" : {
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2.2",
-      "ig-version" : "2.2.0",
-      "package" : "hl7.fhir.uv.smart-app-launch#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/smart-app-launch/STU2.2"
-    },
-    {
-      "name" : "STU 2.1",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.uv.smart-app-launch#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/smart-app-launch/STU2.1"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.uv.smart-app-launch#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/smart-app-launch/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.smart-app-launch#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org/fhir/smart-app-launch/1.0.0"
-    }]
-  },
-  {
-    "name" : "Bidirectional Services eReferrals (BSeR) FHIR IG",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.bser",
-    "description" : "The Bidirectional Services eReferrals (BSeR) FHIR IG provides guidance on STU3 FHIR Resources and US Core IG profiles for use in exchanging a referral request and specific program data from a clinical provider to a typically extra-clinical program service provider, such as a diabetes prevention program, a smoking quitline, or a hypertension management training program. And provides for the return of feedback information from the service program to the referring provider",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/bser/history.html",
-    "canonical" : "http://hl7.org/fhir/us/bser",
-    "ci-build" : "http://build.fhir.org/ig/HL7/bser",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 40,
-      "valuesets" : 2,
-      "codeSystems" : 2,
-      "examples" : 59
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.bser#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/bser/2023Sep"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.bser#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/bser/STU1"
-    }]
-  },
-  {
-    "name" : "FHIR Bulk Data Access",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.us.bulkdata",
-    "description" : "This Implementation Guide defines secure FHIR export Operations that use this capability to provide an authenticated and authorized client with the ability to register as a backend service and retrieve any data in a FHIR server, data on all patients in a server, or data on a group of patients while optionally specifying data since a certain date",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/bulkdata/history.html",
-    "canonical" : "http://hl7.org/fhir/us/bulkdata",
-    "ci-build" : "https://build.fhir.org/ig/HL7/bulk-data",
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.us.bulkdata#0.1.0",
-      "fhir-version" : ["4.0.0"],
-      "url" : "http://hl7.org/fhir/us/bulkdata/2019May"
-    }],
-    "analysis" : {
-      "operations" : 3
-    }
-  },
-  {
-    "name" : "Common Data Models Harmonization FHIR IG",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.us.cdmh",
-    "description" : "The CDMH FHIR IG provides the guidance necessary to map the four common data models namely Sentinel, PCORnet CDM, i2b2 and OMOP to FHIR resources and profiles",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/cdmh/history.html",
-    "canonical" : "http://hl7.org/fhir/us/cdmh",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cdmh",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "trials" : true,
-      "profiles" : 15,
-      "extensions" : 22,
-      "valuesets" : 25,
-      "codeSystems" : 38,
-      "examples" : 15
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.cdmh#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cdmh/STU1"
-    }]
-  },
-  {
-    "name" : "Quality Measure Implementation Guide",
-    "category" : "Quality / CDS",
-    "npm-name" : "hl7.fhir.us.cqfmeasures",
-    "description" : "Provides profiles and guidance for the representation of clinical quality measures in FHIR and Clincal Quality Language (CQL)",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/cqfmeasures/history.html",
-    "canonical" : "http://hl7.org/fhir/us/cqfmeasures",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cqf-measures",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "measures" : true,
-      "profiles" : 21,
-      "extensions" : 36,
-      "operations" : 6,
-      "valuesets" : 5,
-      "codeSystems" : 5,
-      "examples" : 61
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU5 (v5.0.0)",
-      "ig-version" : "5.0.0",
-      "package" : "hl7.fhir.us.cqfmeasures#5.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cqfmeasures/STU5"
-    },
-    {
-      "name" : "STU4 (v4.0.0)",
-      "ig-version" : "4.0.0",
-      "package" : "hl7.fhir.us.cqfmeasures#4.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cqfmeasures/STU4"
-    },
-    {
-      "name" : "STU3",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.us.cqfmeasures#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cqfmeasures/STU3"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.cqfmeasures#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cqfmeasures/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.cqfmeasures#1.0.0",
-      "fhir-version" : ["3.0.2"],
-      "url" : "http://hl7.org/fhir/us/cqfmeasures/STU1"
-    }]
-  },
-  {
-    "name" : "Documentation Templates and Rules",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-dtr",
-    "description" : "Provides a mechanism for delivering and executing payer rules related to documentation requirements for a proposed medication, procedure or other service associated with a patient's insurance coverage",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/davinci-dtr/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-dtr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-dtr",
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "financials" : true,
-      "questionnaire" : true,
-      "profiles" : 6,
-      "extensions" : 2,
-      "operations" : 1,
-      "examples" : 12
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2.2",
-      "ig-version" : "2.2.0",
-      "package" : "hl7.fhir.us.davinci-dtr#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-dtr/2.2.0"
-    }]
-  },
-  {
-    "name" : "Da Vinci Health Record Exchange",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-hrex",
-    "description" : "A library of shared artifacts used by other Da Vinci and payer related implementation guides",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/davinci-hrex/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-hrex",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-ehrx",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "profiles" : 11,
-      "extensions" : 4,
-      "operations" : 1,
-      "valuesets" : 2,
-      "codeSystems" : 1,
-      "examples" : 22
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.davinci-hrex#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-hrex/STU1.1"
-    },
-    {
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-hrex#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-hrex/STU1"
-    }]
-  },
-  {
-    "name" : "electronic Long-Term Services and Supports Implementation Guide",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.eltss",
-    "description" : "Provides guidance to US Realm implementers to use the FHIR for implementing access and exchange Electronic Long-Term Services & Supports (eLTSS) Dataset data elements",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/eLTSS/history.html",
-    "ci-build" : "http://build.fhir.org/ig/HL7/eLTSS",
-    "canonical" : "http://hl7.org/fhir/us/eltss",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "questionnaire" : true,
-      "profiles" : 13,
-      "extensions" : 3,
-      "logicals" : 3,
-      "valuesets" : 2,
-      "codeSystems" : 2,
-      "examples" : 5
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.eltss#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/eltss/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.eltss#1.0.0",
-      "fhir-version" : ["4.0.0"],
-      "url" : "http://hl7.org/fhir/us/eltss/STU1"
-    }]
-  },
-  {
-    "name" : "Patient Reported Outcomes (PRO) FHIR IG",
-    "category" : "Personal Healthcare",
-    "npm-name" : "hl7.fhir.us.patient-reported-outcomes",
-    "description" : "This IG provides the necessary guidance to use FHIR for Patient Reported Outcomes",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/patient-reported-outcomes/history.html",
-    "canonical" : "http://hl7.org/fhir/us/patient-reported-outcomes",
-    "ci-build" : "http://build.fhir.org/ig/HL7/patient-reported-outcomes",
-    "analysis" : {
-      "rest" : true
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.us.patient-reported-outcomes#0.2.0",
-      "fhir-version" : ["4.0.0"],
-      "url" : "http://hl7.org/fhir/us/patient-reported-outcomes/2019May"
-    }]
-  },
-  {
-    "name" : "Pharmacist Care Plan FHIR IG",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.phcp",
-    "description" : "This is an electronic care plan with enhanced Medications / Immunizations content based on the templates in the HL7 Implementation Guide for C-CDA Release 2.1: Consolidated CDA for Clinical Notes, represented using FHIR profiles",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/phcp/history.html",
-    "canonical" : "http://hl7.org/fhir/us/phcp",
-    "ci-build" : "http://build.fhir.org/ig/HL7/PhCP",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 10,
-      "examples" : 16
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.phcp#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/phcp/STU1"
-    }]
-  },
-  {
-    "name" : "Vital Records Mortality and Morbidity Reporting FHIR IG",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.vrdr",
-    "description" : "The VRDR FHIR IG provides guidance regarding the use of FHIR resources for the bidirectional exchange of mortality data between State-run PHA Vital Records offices and NCHS",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/vrdr/history.html",
-    "canonical" : "http://hl7.org/fhir/us/vrdr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/vrdr",
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "profiles" : 34,
-      "extensions" : 4,
-      "examples" : 34
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU3",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.us.vrdr#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vrdr/STU3"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.2.0",
-      "package" : "hl7.fhir.us.vrdr#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vrdr/STU2.2"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.vrdr#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vrdr/STU2.1"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.vrdr#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vrdr/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.vrdr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vrdr/STU1"
-    }]
-  },
-  {
-    "name" : "Womens Health Technology Coordinated Registry Network FHIR IG",
-    "category" : "Clinical Registries",
-    "npm-name" : "hl7.fhir.us.womens-health-registries",
-    "description" : "The purpose of the IG to provide the necessary guidance to use FHIR to build registries specific to monitoring Womens Health",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/womens-health-registries/history.html",
-    "canonical" : "http://hl7.org/fhir/us/womens-health-registries",
-    "ci-build" : "http://build.fhir.org/ig/HL7/coordinated-registry-network",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 3
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Withdrawn",
-      "ig-version" : "0.2.0-withdrawal",
-      "package" : "hl7.fhir.us.womens-health-registries#0.2.0-withdrawal",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/womens-health-registries/0.2.0-withdrawal"
-    }]
-  },
-  {
-    "name" : "Personal Health Device FHIR IG",
-    "category" : "Personal Healthcare",
-    "npm-name" : "hl7.fhir.uv.phd",
-    "description" : "The IG provides a mapping of IEEE 11073 20601 Personal Health Device data to FHIR",
-    "authority" : "HL7",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/uv/phd/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/phd",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 11,
-      "valuesets" : 7,
-      "codeSystems" : 4
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/phd",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.uv.phd#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/phd/STU2"
-    }]
-  },
-  {
-    "name" : "Provider Directory IG",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.au.pd",
-    "description" : "This implementation guide is based upon STU3 FHIR standard and is the Australian variant of the Provider Directory IG. It outlines the key data elements for any provider directory and basic query guidance. The components developed in this guide are intended to provide a foundation for a central or distributed Provider or Healthcare Directory",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "au",
-    "history" : "http://hl7.org.au/fhir/pd/history.html",
-    "canonical" : "http://hl7.org.au/fhir/pd",
-    "ci-build" : "http://build.fhir.org/ig/hl7au/au-fhir-pd",
-    "editions" : [{
-      "name" : "Release 1 Qa-preview",
-      "ig-version" : "0.6.0",
-      "package" : "hl7.fhir.au.pd#0.6.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://hl7.org.au/fhir"
-    }],
-    "analysis" : {
-      "error" : "Unable to find package hl7.fhir.au.pd#0.6.0"
-    },
-    "language" : ["en"]
-  },
-  {
-    "name" : "Argonaut Clinical Notes Implementation Guide",
-    "category" : "EHR Access",
-    "npm-name" : "argonaut.us.clinicalnotes",
-    "description" : "This implementation guide provides implementers with FHIR profiles and guidance to create, use, and share Clinical Notes",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://fhir.org/guides/argonaut/clinicalnotes/history.html",
-    "canonical" : "http://fhir.org/guides/argonaut/clinicalnotes",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/clinicalnotes",
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0",
-      "package" : "argonaut.us.clinicalnotes#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.org/guides/argonaut/clinicalnotes/1.0.0"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id argonaut.us.clinicalnotes#1.0.0"
-    },
-    "language" : ["en"]
-  },
-  {
-    "name" : "Argonaut Questionnaire Implementation Guide",
-    "category" : "EHR Access",
-    "npm-name" : "argonaut.us.questionnaire",
-    "description" : "This implementation guide provides implementers with FHIR RESTful APIs and guidance to create, use and share between organizations standard assessment forms and the assessment responses",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://fhir.org/guides/argonaut/questionnaire/history.html",
-    "canonical" : "http://fhir.org/guides/argonaut/questionnaire",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/questionnaire",
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0",
-      "package" : "argonaut.us.questionnaire#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.org/guides/argonaut/questionnaire/1.0.0"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id argonaut.us.questionnaire#1.0.0"
-    },
-    "language" : ["en"]
-  },
-  {
-    "name" : "Danish Core Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.dk.core",
-    "description" : "Base danish national implementation guide",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "language" : ["en"],
-    "history" : "http://hl7.dk/fhir/core/history.html",
-    "canonical" : "http://hl7.dk/fhir/core",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 10,
-      "extensions" : 2,
-      "valuesets" : 6,
-      "codeSystems" : 15,
-      "examples" : 12
-    },
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/dk-core",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "3.6.0",
-      "package" : "hl7.fhir.dk.core#3.6.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.dk/fhir/core/3.6.0"
-    }]
-  },
-  {
-    "name" : "Swiss Core Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-core",
-    "description" : "Base swiss national implementation guide",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-core/history.html",
-    "canonical" : "http://fhir.ch/ig/ch-core",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-core",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 5",
-      "ig-version" : "5.0.0",
-      "package" : "ch.fhir.ig.ch-core#5.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-core/5.0.0"
-    }],
-    "language" : ["en"]
-  },
-  {
-    "name" : "Swiss Guide Template",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.template",
-    "description" : "HL7 Switzerland FHIR Implementation Guide Template",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/template/history.html",
-    "canonical" : "http://fhir.ch/ig/template",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ig-template/index.html",
-    "editions" : [{
-      "name" : "STU",
-      "ig-version" : "0.4.0",
-      "package" : "ch.fhir.ig.template#0.4.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/template/0.4.0"
-    }],
-    "language" : ["en"]
-  },
-  {
-    "name" : "Swiss Cancer Registration Implementation Guide (CH-CRL)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-crl",
-    "description" : "Implementation guide for the Cancer Registry Law (CRL)",
-    "authority" : "FOPH (CH)",
-    "product" : ["fhir"],
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-crl/history.html",
-    "canonical" : "http://fhir.ch/ig/ch-crl",
-    "ci-build" : "http://build.fhir.org/ig/ahdis/ch-crl/index.html",
-    "editions" : [{
-      "name" : "STU",
-      "ig-version" : "0.2.1",
-      "package" : "ch.fhir.ig.ch-crl#0.2.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-crl"
-    },
-    {
-      "name" : "STU",
-      "ig-version" : "0.1.1",
-      "package" : "ch.fhir.ig.ch-crl#0.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-crl/0.1.1"
-    }],
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 34,
-      "extensions" : 1,
-      "logicals" : 1,
-      "valuesets" : 15,
-      "codeSystems" : 15,
-      "examples" : 137
-    },
-    "language" : ["en"]
-  },
-  {
-    "name" : "Audit Trail Consumption (CH-ATC)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.atc",
-    "description" : "National Integration Profile for the Swiss Electronic Patient Record",
-    "authority" : "FOPH",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-atc/history.html",
-    "canonical" : "http://fhir.ch/ig/ch-atc",
-    "ci-build" : "http://build.fhir.org/ig/ahdis/ch-atc/index.html",
-    "editions" : [{
-      "ig-version" : "3.3.0",
-      "name" : "2022-12-28",
-      "package" : "ch.fhir.ig.ch-atc#3.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-atc/index.html"
-    },
-    {
-      "name" : "Release 24.6.2019",
-      "ig-version" : "1.2.0",
-      "package" : "ch.fhir.ig.ch-atc#1.2.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.ch/ig/ch-atc/1.2.0/index.html"
-    }]
-  },
-  {
-    "name" : "Order & Referral by Form (CH-ORF)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-orf",
-    "description" : "The Order & Referral by Form (CH-ORF) Profile describes how forms for eReferrals, requests for information (such as diagnostic imaging results, lab results, discharge reports etc.) can be defined, deployed and used in order to achieve a syntactical and semantically consistent cross enterprise information exchange.",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-orf/history.html",
-    "canonical" : "http://fhir.ch/ig/ch-orf",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-orf",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 3",
-      "ig-version" : "3.0.0",
-      "package" : "ch.fhir.ig.ch-orf#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-orf/3.0.0"
-    }],
-    "language" : ["en"]
-  },
-  {
-    "name" : "Swiss eMedication Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-emed",
-    "description" : "The CH EMED implementation guide describes the FHIR representation of the defined documents for the exchange of medication information",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-emed/history.html",
-    "canonical" : "http://fhir.ch/ig/ch-emed",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-emed",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 5",
-      "ig-version" : "5.0.0",
-      "package" : "ch.fhir.ig.ch-emed#5.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-emed/5.0.0"
-    }],
-    "language" : ["en"]
-  },
-  {
-    "name" : "mednet Implementation Guide",
-    "category" : "Patient Summary",
-    "npm-name" : "swiss.mednet.fhir",
-    "description" : "The mednet.swiss implementation guide describes the FHIR profiles used to interface with the mednet software",
-    "authority" : "novcom AG (CH)",
-    "product" : ["fhir"],
-    "country" : "ch",
-    "history" : "https://mednet.swiss/fhir/history.html",
-    "canonical" : "https://mednet.swiss/fhir",
-    "analysis" : {
-    },
-    "language" : ["en"]
-  },
-  {
-    "name" : "US Drug Formulary",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.Davinci-drug-formulary",
-    "description" : "API-based data exchange to Third-Party Applications via Member-authorized sharing of Health Plan's Prescription Drug Formulary.",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/Davinci-drug-formulary/history.html",
-    "canonical" : "http://hl7.org/fhir/us/Davinci-drug-formulary",
-    "ci-build" : "https://build.fhir.org/ig/HL7/davinci-pdex-formulary",
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.Davinci-drug-formulary#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/Davinci-drug-formulary/STU1"
-    }],
-    "analysis" : {
-      "content" : true,
-      "medsMgmt" : true,
-      "profiles" : 2,
-      "extensions" : 13,
-      "valuesets" : 4,
-      "codeSystems" : 4,
-      "examples" : 11
-    },
-    "language" : ["en"]
-  },
-  {
-    "name" : "Da Vinci CDex",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-cdex",
-    "description" : "Provider-to-payer and payer-related provider-to-provider data exchange to improve care coordination, support risk adjustment, ease quality management, facilitate claims auditing and confirm medical necessity, improve member experience, and support orders and referrals.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-cdex/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-cdex",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-ecdx",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "carePlanning" : true,
-      "profiles" : 1,
-      "operations" : 1,
-      "valuesets" : 3,
-      "codeSystems" : 1,
-      "examples" : 19
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.davinci-cdex#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-cdex/STU2.1"
-    },
-    {
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.davinci-cdex#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-cdex/STU2"
-    },
-    {
-      "name" : "STU1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.davinci-cdex#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-cdex/STU1.1"
-    },
-    {
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-cdex#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-cdex/STU1"
-    }]
-  },
-  {
-    "name" : "Da Vinci PDex",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-pdex",
-    "description" : "Payer data exchange with providers to support care coordination. Member-authorized sharing to Third-Party applications of Health Plan's Healthcare Service Network, Pharmacy Network and Prescription Drug Formulary",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-pdex/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-pdex",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-epdx",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 5,
-      "extensions" : 6,
-      "operations" : 1,
-      "valuesets" : 12,
-      "codeSystems" : 13,
-      "examples" : 36
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2.1",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.davinci-pdex#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pdex/STU2.1"
-    }]
-  },
-  {
-    "name" : "CDISC Lab Semantics in FHIR",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.cdisc-lab",
-    "description" : "The IG shows how laboratory data in FHIR format can be converted into the CDISC LAB or LB format",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cdisc-lab/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/cdisc-lab",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cdisc-lab",
-    "analysis" : {
-      "rest" : true
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.cdisc-lab#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cdisc-lab/STU1"
-    }]
-  },
-  {
-    "name" : "Healthcare Associated Infection Reports (HAI) Long Term Care Facilities (LTCF)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.hai-ltcf",
-    "description" : "Long term care facility (LTCF) healthcare-associated infection (HAI) reporting to CDC National Healthcare Safety Network (NHSN) to track infections and prevention process measures in a systematic way, which allows identification of problems and care improvement",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/hai-ltcf/history.html",
-    "canonical" : "http://hl7.org/fhir/us/hai-ltcf",
-    "analysis" : {
-      "valuesets" : 4,
-      "codeSystems" : 2
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/HAI-LTCF",
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.hai-ltcf#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/hai-ltcf/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.hai-ltcf#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/hai-ltcf/STU1"
-    }]
-  },
-  {
-    "name" : "Da Vinci Unsolicited Notifications (Alerts)",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-alerts",
-    "description" : "The goal of this IG is to support the real-time exchange of alerts and notifications that impact patient care and value based or risk based services",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-alerts/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-alerts",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-alerts",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 8,
-      "valuesets" : 4,
-      "codeSystems" : 1,
-      "examples" : 11
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.davinci-alerts#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-alerts/STU1.1"
-    },
-    {
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-alerts#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-alerts/STU1"
-    }]
-  },
-  {
-    "name" : "Da Vinci Payer Coverage Decision Exchange (PCDE) FHIR IG",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-pcde",
-    "description" : "Payer coverage decision exchange will promote continuity of treatment when a member moves from one covered payer to another without increasing provider burden or cost to the member. This IG enables member-authorized sharing of treatment, conditions, authorizations, relevant guidelines and supporting documentation from an original payer to a new payer when a patient changes coverage plans.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-pcde/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-pcde",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-pcde",
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 5,
-      "valuesets" : 3,
-      "codeSystems" : 1,
-      "examples" : 5
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-pcde#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pcde/STU1"
-    }]
-  },
-  {
-    "name" : "Breast Radiology Report (BRR)",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.breast-radiology",
-    "description" : "Breast Radiology CIMI Logical Models and FHIR Profiles",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/breast-radiology/history.html",
-    "canonical" : "http://hl7.org/fhir/us/breast-radiology",
-    "ci-build" : "http://build.hl7.org/fhir/us/breast-radiology",
-    "analysis" : {
-      "examples" : 125
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.us.breast-radiology#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/breast-radiology/2020May"
-    }]
-  },
-  {
-    "name" : "FHIR Clinical Guidelines",
-    "category" : "Quality / CDS",
-    "npm-name" : "hl7.fhir.uv.cpg",
-    "description" : "This implementation guide is a multi-stakeholder effort to use FHIR resources to build shareable and computable representations of the content of clinical care guidelines. The guide focuses on common patterns in clinical guidelines, establishing profiles, conformance requirements, and guidance for the patient-independent, as well as analogous patterns for the patient-specific representation of guideline recommendations",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cpg/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/cpg",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cqf-recommendations",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "medsMgmt" : true,
-      "measures" : true,
-      "questionnaire" : true,
-      "profiles" : 102,
-      "extensions" : 38,
-      "operations" : 5,
-      "valuesets" : 9,
-      "codeSystems" : 7,
-      "examples" : 441
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.uv.cpg#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cpg/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.cpg#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cpg/STU1"
-    }]
-  },
-  {
-    "name" : "Minimal Common Oncology Data Elements (mCODE)",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.mcode",
-    "description" : "This IG specifies a core set of common data elements for cancer that is clinically applicable in every electronic patient record with a cancer diagnosis. It is intended to enable standardized information exchange among EHRs/oncology information systems and reuse of data by other stakeholders (e.g. quality measurement, research).",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/mcode/history.html",
-    "canonical" : "http://hl7.org/fhir/us/mcode",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-mCODE-ig",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "profiles" : 28,
-      "extensions" : 14,
-      "operations" : 1,
-      "valuesets" : 96,
-      "codeSystems" : 2,
-      "examples" : 97
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU4",
-      "ig-version" : "4.0.0",
-      "package" : "hl7.fhir.us.mcode#4.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mcode/STU4"
-    },
-    {
-      "name" : "STU 3",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.us.mcode#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mcode/STU3"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.mcode#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mcode/STU2.1"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.mcode#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mcode/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.mcode#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mcode/STU1"
-    }]
-  },
-  {
-    "name" : "Da Vinci Prior Authorization Support (PAS) FHIR IG",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-pas",
-    "description" : "This IG allows providers the ability to easily identify the need for payer authorizations, assemble necessary information, identify and supply missing information and submit it to the payer electronically and receive a response in real time within the clinical workflow.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-pas/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-pas",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-pas",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 23,
-      "extensions" : 37,
-      "operations" : 2,
-      "valuesets" : 12,
-      "codeSystems" : 6,
-      "examples" : 29
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.2.1",
-      "package" : "hl7.fhir.us.davinci-pas#2.2.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pas/2.2.1"
-    }]
-  },
-  {
-    "name" : "FHIR Bulk Data Access (Flat FHIR)",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.uv.bulkdata",
-    "description" : "Defines a way to efficiently access large volumes of information on a group of individuals from an EHR",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/bulkdata/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/bulkdata",
-    "ci-build" : "http://build.fhir.org/ig/HL7/bulk-data",
-    "analysis" : {
-      "rest" : true,
-      "operations" : 3,
-      "valuesets" : 1,
-      "codeSystems" : 1
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 3",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.uv.bulkdata#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/bulkdata/STU3"
-    }]
-  },
-  {
-    "name" : "Basisgegevensset Zorg || Patient Summary",
-    "npm-name" : "nictiz.fhir.nl.stu3.zib2017",
-    "category" : "Patient Summary",
-    "description" : "The Basisgegevensset Zorg, aka BgZ, is the minimum set of patient data that is important for continuity of care and is relevant irrespective of specialism, patient conditions and type of physicians. This set of patient data is recorded comparatively by all healthcare providers. This facilitates information exchange. The BgZ has been made consistent with the European Patient Summary.",
-    "authority" : "Nictiz (NL)",
-    "product" : ["fhir"],
-    "country" : "nl",
-    "language" : ["nl", "en"],
-    "history" : "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2019.01_OntwerpBGZ_2017#Release_notes",
-    "canonical" : "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2019.01_OntwerpBGZ_2017",
-    "ci-build" : "https://informatiestandaarden.nictiz.nl/wiki/MedMij:Vdraft_OntwerpBGZ_2017",
-    "editions" : [{
-      "name" : "Normative - MMVN 3",
-      "ig-version" : "2.1.3",
-      "package" : "nictiz.fhir.nl.stu3.zib2017#2.1.3",
-      "fhir-version" : ["3.0.1"],
-      "url" : "https://informatiestandaarden.nictiz.nl/wiki/MedMij:V2019.01_OntwerpBGZ_2017#Use_case_1:_Raadplegen_Basisgegevensset_Zorg_in_persoonlijke_gezondheidsomgeving"
-    }],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "profiles" : 144,
-      "extensions" : 70,
-      "valuesets" : 261
-    }
-  },
-  {
-    "name" : "Davinci pdex Plan Net",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.us.davinci-pdex-plan-net",
-    "description" : "A subset of the functionality described in the Validated healthcare directory IG",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-pdex-plan-net",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-pdex-plan-net",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 9,
-      "extensions" : 12,
-      "valuesets" : 24,
-      "codeSystems" : 14,
-      "examples" : 49
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.2.0",
-      "package" : "hl7.fhir.us.davinci-pdex-plan-net#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1.2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.davinci-pdex-plan-net#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-pdex-plan-net#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1"
-    }]
-  },
-  {
-    "name" : "Argonaut Clinical Notes Implementation Guide",
-    "category" : "EHR Access",
-    "npm-name" : "fhir.argonaut.clinicalnotes",
-    "description" : "This implementation guide provides implementers with FHIR profiles and guidance to create, use, and share Clinical Notes",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://fhir.org/guides/argonaut/clinicalnotes/history.html",
-    "canonical" : "http://fhir.org/guides/argonaut/clinicalnotes",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/clinicalnotes",
-    "language" : ["en"],
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0",
-      "package" : "fhir.argonaut.clinicalnotes#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.org/guides/argonaut/clinicalnotes/1.0.0"
-    }],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "profiles" : 2,
-      "valuesets" : 3,
-      "codeSystems" : 1
-    }
-  },
-  {
-    "name" : "Argonaut Questionnaire Implementation Guide",
-    "category" : "EHR Access",
-    "npm-name" : "fhir.argonaut.questionnaire",
-    "description" : "Thi IG provides guidance to support interchange of simple forms based on the Questionnaire and QuestionnaireResponse resources: it provides implementers with FHIR RESTful APIs and guidance to create, use and share between organizations standard assessment forms and the assessment responses",
-    "authority" : "Argonaut (US)",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://fhir.org/guides/argonaut/questionnaire/history.html",
-    "canonical" : "http://fhir.org/guides/argonaut/questionnaire",
-    "ci-build" : "http://build.fhir.org/ig/argonautproject/questionnaire",
-    "language" : ["en"],
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0",
-      "package" : "fhir.argonaut.questionnaire#1.0.0",
-      "fhir-version" : ["3.0.1"],
-      "url" : "http://fhir.org/guides/argonaut/questionnaire/1.0.0"
-    }],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "questionnaire" : true,
-      "profiles" : 4,
-      "extensions" : 5,
-      "operations" : 1
-    }
-  },
-  {
-    "name" : "CARIN Real-time Pharmacy Benefit Check",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.carin-rtpbc",
-    "description" : "This is a guide for implementing a consumer-focused Real-time Pharmacy Benefit Check (RTPBC) process using HL7 FHIR® R4.Using RTPBC, a patient can learn the cost and insurance coverage related to medications they’ve been prescribed",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/carin-rtpbc/history.html",
-    "canonical" : "http://hl7.org/fhir/us/carin-rtpbc",
-    "ci-build" : "http://build.fhir.org/ig/HL7/carin-rtpbc",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "messaging" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 10,
-      "extensions" : 2,
-      "valuesets" : 9,
-      "codeSystems" : 3,
-      "examples" : 16
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.carin-rtpbc#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/carin-rtpbc/2026May"
-    }]
-  },
-  {
-    "name" : "CARIN Blue Button Implementation Guide",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.carin-bb",
-    "description" : "Implementation guide for an API similar to the CMS Medicare Blue Button 2.0 API, FHIR R3 based, that will allow consumer-directed exchange of commercial Health Plan/Payer adjudicated claims data to meet the requirements of the CMS Interoperability and Patient Access proposed rule.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/carin-bb/history.html",
-    "canonical" : "http://hl7.org/fhir/us/carin-bb",
-    "ci-build" : "http://build.fhir.org/ig/HL7/carin-bb",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 10,
-      "valuesets" : 48,
-      "codeSystems" : 36,
-      "examples" : 28
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.2.0",
-      "package" : "hl7.fhir.us.carin-bb#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/carin-bb/STU2.2"
-    }]
-  },
-  {
-    "name" : "Risk Based Contracts Member Attribution List FHIR IG",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-atr",
-    "description" : "Support the real-time exchange of alerts and notifications that impact patient care and value based or risk based services.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-atr/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-atr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-atr",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 8,
-      "extensions" : 5,
-      "valuesets" : 1,
-      "codeSystems" : 1,
-      "examples" : 14
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.davinci-atr#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-atr/STU2.1"
-    },
-    {
-      "name" : "STU2 Release 1",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.davinci-atr#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-atr/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-atr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-atr/STU1"
-    }]
-  },
-  {
-    "name" : "Basisprofil DE",
-    "category" : "National Base",
-    "npm-name" : "basisprofil.de",
-    "description" : "German Base Profiles",
-    "authority" : "HL7 Deutschland",
-    "product" : ["fhir"],
-    "country" : "de",
-    "history" : "http://ig.fhir.de/basisprofile-de",
-    "canonical" : "http://fhir.de",
-    "ci-build" : "https://simplifier.net/Basisprofil-DE-R4",
-    "language" : ["de"],
-    "editions" : [{
-      "name" : "STU3",
-      "ig-version" : "0.2.30",
-      "fhir-version" : ["3.0.1"],
-      "package" : "basisprofil.de#0.2.30",
-      "url" : "http://ig.fhir.de/basisprofile-de/0.2.30"
-    },
-    {
-      "name" : "R4",
-      "ig-version" : "0.9.1-alpha2",
-      "fhir-version" : ["4.0.1"],
-      "package" : "de.basisprofil.r4#0.9.1-alpha2",
-      "url" : "https://simplifier.net/guide/basisprofil-de-r4/home"
-    }],
-    "analysis" : {
-      "error" : "no core dependency or FHIR Version found in the Package definition",
-      "content" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 17,
-      "extensions" : 17,
-      "valuesets" : 10,
-      "codeSystems" : 17
-    }
-  },
-  {
-    "name" : "FHIR Data Segmentation for Privacy",
-    "category" : "Privacy / Security",
-    "npm-name" : "hl7.fhir.uv.security-label-ds4p",
-    "description" : "Guidance for applying security labels in FHIR",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/security-label-ds4p/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/security-label-ds4p",
-    "ci-build" : "http://hl7.org/fhir/ig/HL7/security-label-ds4p",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "extensions" : 6,
-      "valuesets" : 8,
-      "examples" : 8
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.security-label-ds4p#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/security-label-ds4p/STU1"
-    }]
-  },
-  {
-    "name" : "FHIR Shorthand",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.uv.shorthand",
-    "description" : "FHIR Shorthand (FSH) is a domain-specific language (DSL) for defining the contents of FHIR IGs to allow the author to express their intent with fewer concerns about underlying FHIR mechanics",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/shorthand/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/shorthand",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-shorthand",
-    "language" : ["en"],
-    "analysis" : {
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 3 Normative+trial-use",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.uv.shorthand#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/shorthand/N2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.shorthand#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/shorthand/STU1"
-    }]
-  },
-  {
-    "name" : "Post Acute Orders FHIR IG",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.dme-orders",
-    "description" : "Electronic exchange of post-acute orders",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/dme-orders/history.html",
-    "canonical" : "http://hl7.org/fhir/us/dme-orders",
-    "ci-build" : "http://build.fhir.org/ig/HL7/dme-orders",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 11,
-      "extensions" : 3,
-      "valuesets" : 2,
-      "codeSystems" : 1,
-      "examples" : 26
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.us.dme-orders#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/dme-orders/2020Sep"
-    }]
-  },
-  {
-    "name" : "Application Data Exchange Assessment Framework and Functional Requirements for Mobile Health",
-    "category" : "Personal Healthcare",
-    "npm-name" : "hl7.fhir.uv.mhealth-framework",
-    "description" : "Document the functional requirements that can be used to assess devices, applications, and FHIR profiles to ensure that the essential data needed for clinical, patient and research uses is present in communications between applications",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/mhealth-framework/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/mhealth-framework",
-    "ci-build" : "http://hl7.org/fhir/uv/mhealth-framework",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 2
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.uv.mhealth-framework#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/mhealth-framework/2020May"
-    }]
-  },
-  {
-    "name" : "US Drug Formulary",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.davinci-drug-formulary",
-    "description" : "API-based data exchange to Third-Party Applications via Member-authorized sharing of Health Plan's Prescription Drug Formulary.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-drug-formulary/history.html",
-    "canonical" : "http://hl7.org/fhir/us/davinci-drug-formulary",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-pdex-formulary",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 5,
-      "extensions" : 11,
-      "valuesets" : 10,
-      "codeSystems" : 8,
-      "examples" : 22
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.davinci-drug-formulary#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-drug-formulary/STU2.1"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.1",
-      "package" : "hl7.fhir.us.davinci-drug-formulary#2.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-drug-formulary/STU2.0.1"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.davinci-drug-formulary#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-drug-formulary/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.davinci-drug-formulary#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-drug-formulary/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.us.davinci-drug-formulary#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-drug-formulary/STU1.0.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-drug-formulary#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-drug-formulary/STU1"
-    }]
-  },
-  {
-    "name" : "HL7 Italia FHIR Implementation Guide (base)",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.it.base",
-    "description" : "This guide describes a set of FHIR base profiles and reference logical models to be used in the Italian context",
-    "authority" : "HL7 Italia",
-    "product" : ["fhir"],
-    "country" : "it",
-    "history" : "http://hl7.it/fhir/history.html",
-    "canonical" : "http://hl7.it/fhir/base",
-    "ci-build" : "http://hl7.it/fhir/base",
-    "language" : ["it"],
-    "editions" : [{
-      "name" : "Initial Public Comment ballot (Jun 2020 Ballot)",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.it.base#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.it/fhir/base/2020-06"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id hl7.fhir.it.base#0.1.0"
-    }
-  },
-  {
-    "name" : "Dental Data Exchange",
-    "category" : "Clinical Observations",
-    "npm-name" : "hl7.fhir.us.dental-data-exchange",
-    "description" : "This FHIR R4 IG defines exchange of medical and dental information exchange between medical/dental and dental/dental realms, including referral and corresponding consult note using US-core, CCDAonFHIR, Occupational Data for Health, and Da Vinci profiles.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/dental-data-exchange/history.html",
-    "canonical" : "http://hl7.org/fhir/us/dental-data-exchange",
-    "ci-build" : "http://build.fhir.org/ig/HL7/dental-data-exchange",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 7,
-      "valuesets" : 5,
-      "codeSystems" : 1,
-      "examples" : 64
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.dental-data-exchange#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/dental-data-exchange/STU1"
-    }]
-  },
-  {
-    "name" : "Order Catalog Implementation Guide",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.uv.order-catalog",
-    "description" : "An Order Catalog is an administered homogeneous collection of items such as medication products, laboratory tests, procedures, medical devices or knowledge artifacts such as order sets, which support the ordering process, or more generally the healthcare process.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/order-catalog/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/order-catalog",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-order-catalog",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "diagnostics" : true,
-      "profiles" : 11,
-      "extensions" : 8,
-      "valuesets" : 4,
-      "codeSystems" : 3,
-      "examples" : 60
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.uv.order-catalog#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/order-catalog/2020Sep"
-    }]
-  },
-  {
-    "name" : "SMART Web Messaging Implementation Guide: STU1",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.uv.smart-web-messaging",
-    "description" : "SMART Web Messaging enables tight UI integration between EHRs and embedded SMART apps via HTML5’s Web Messaging. SMART Web Messaging allows applications to push unsigned orders, note snippets, risk scores, or UI suggestions directly to the clinician’s EHR session. Built on the browser’s javascript window.postMessage function, SMART Web Messaging is a simple, native API for health apps embedded within the user’s workflow",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/smart-web-messaging/history.html",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/HL7/smart-web-messaging",
-    "canonical" : "http://hl7.org/fhir/uv/smart-web-messaging",
-    "analysis" : {
-      "examples" : 1
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.smart-web-messaging#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/smart-web-messaging/STU1"
-    }]
-  },
-  {
-    "name" : "HL7 Version 2 to FHIR",
-    "npm-name" : "hl7.fhir.uv.v2mappings",
-    "description" : "The HL7 V2 to FHIR Implementation Guide supports the mapping of HL7 Version 2 messages segments, datatypes and vocabulary to HL7 FHIR Release 4.0 Bundles, Resources, Data Types and Coding Systems.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/v2mappings/history.html",
-    "canonical" : "http://hl7.org/fhir/uv/v2mappings",
-    "ci-build" : "http://build.fhir.org/ig/HL7/v2-to-fhir",
-    "language" : ["en"],
-    "category" : "Mappings to Other Standards",
-    "analysis" : {
-      "content" : true,
-      "extensions" : 57,
-      "examples" : 175
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.v2mappings#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/v2mappings/STU1"
-    }]
-  },
-  {
-    "name" : "IHE FormatCode vocabulary",
-    "category" : "EHR Access",
-    "npm-name" : "ihe.formatcode.fhir",
-    "description" : "Defines IHE vocabulary for FormatCode and the IHE managed ValueSet for FormatCode for use with Document Sharing such as XDS, XCA, XDM, XDR, and MHD.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "http://profiles.ihe.net/fhir/ihe.formatcode.fhir/history.html",
-    "ci-build" : "http://build.fhir.org/ig/IHE/FormatCode",
-    "canonical" : "https://profiles.ihe.net/fhir/ihe.formatcode.fhir",
-    "analysis" : {
-      "valuesets" : 1,
-      "codeSystems" : 1
-    },
-    "language" : ["en"],
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication Normative",
-      "ig-version" : "1.5.0",
-      "package" : "ihe.formatcode.fhir#1.5.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/fhir/ihe.formatcode.fhir/1.5.0"
-    }]
-  },
-  {
-    "name" : "HL7 Terminology",
-    "category" : "Terminology",
-    "npm-name" : "hl7.terminology",
-    "description" : "Terminology",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://terminology.hl7.org/history.html",
-    "language" : ["en"],
-    "canonical" : "http://terminology.hl7.org",
-    "ci-build" : "http://build.fhir.org/ig/HL7/UTG",
-    "analysis" : {
-      "content" : true,
-      "extensions" : 9,
-      "valuesets" : 2483,
-      "codeSystems" : 1078
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publications",
-      "ig-version" : "7.1.0",
-      "package" : "hl7.terminology#7.1.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://terminology.hl7.org/7.1.0"
-    }]
-  },
-  {
-    "name" : "Situational Awareness for Novel Epidemic Response",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.uv.saner",
-    "description" : "The SANER Implementation Guide enables transmission of high level situational awareness information from inpatient facilities to centralized data repositories to support the treatment of novel influenza-like illness.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/saner/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/saner",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-saner",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "measures" : true,
-      "profiles" : 10,
-      "extensions" : 5,
-      "operations" : 5,
-      "valuesets" : 49,
-      "codeSystems" : 6,
-      "examples" : 169
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.saner#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/saner/STU1"
-    }]
-  },
-  {
-    "name" : "Making Ehr Data MOre Available to Research and Public Health (MedMorph)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.fhir-medmorph",
-    "description" : "The The MedMorph FHIR IG enables Public Health and Research Organizations to access EHR data without increasing provider burden.",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/fhir-medmorph/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/fhir-medmorph",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-medmorph",
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.us.fhir-medmorph#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/fhir-medmorph/2021Jan"
-    }],
-    "analysis" : {
-      "error" : "Unable to resolve package id hl7.fhir.us.fhir-medmorph#0.1.0"
-    }
-  },
-  {
-    "name" : "PACIO Functional Status Implementation Guide",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.fhir.us.pacio-fs",
-    "description" : "FHIR R4 IG that leverages eLTSS and utilizes the Self-Care, Mobility and Prior Device use sections of CMS assessment forms (IRF-PAI, MDS, OASIS, LTCH) to enable the sharing of functional status information when a patient moves from one clinical care setting to another.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pacio-fs/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pacio-fs",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-pacio-functional-status",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 4,
-      "extensions" : 3,
-      "valuesets" : 1,
-      "codeSystems" : 1,
-      "examples" : 84
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.pacio-fs#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pacio-fs/STU1"
-    }]
-  },
-  {
-    "name" : "PACIO Cognitive Status Implementation Guide",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.fhir.us.pacio-cs",
-    "description" : "FHIR R4 IG that leverages eLTSS and utilizes the Confusion Assessment Method (CAM) assessment to enable the sharing of cognitive status information when a patient moves from one clinical care setting to another.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pacio-cs/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pacio-cs",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-pacio-cognitive-status",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 4,
-      "extensions" : 3,
-      "valuesets" : 1,
-      "codeSystems" : 1,
-      "examples" : 68
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.pacio-cs#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pacio-cs/STU1"
-    }]
-  },
-  {
-    "name" : "Specialty Medication Enrollment",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.us.specialty-rx",
-    "description" : "This FHIR IG focuses on the exchange of data (Demographic, prescription, clinical and financial) for dispensing specialty medications by pharmacies as well as facilitating the enrollment of patients in programs offered by third parties such as but not limited to Hub vendors and Pharmaceutical manufacturers.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/specialty-rx/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/specialty-rx",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "messaging" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "financials" : true,
-      "medsMgmt" : true,
-      "profiles" : 18,
-      "valuesets" : 2,
-      "codeSystems" : 4,
-      "examples" : 16
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-specialty-rx",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.specialty-rx#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/specialty-rx/STU2"
-    },
-    {
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.specialty-rx#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/specialty-rx/STU1"
-    }]
-  },
-  {
-    "name" : "Vital Records Common Profile Library",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.vr-common-library",
-    "description" : "Library containing profiles used by other Vital Records IGs such as Birth and Fetal Death Reporting and Birth Defects Reporting.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/vr-common-library/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/vr-common-library",
-    "ci-build" : "http://build.fhir.org/ig/HL7/vr-common-library",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 30,
-      "extensions" : 4,
-      "valuesets" : 5,
-      "examples" : 35
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.vr-common-library#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vr-common-library/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.vr-common-library#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vr-common-library/STU1.1"
-    },
-    {
-      "name" : "STU 1 on FHIR R4",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.vr-common-library#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vr-common-library/STU1"
-    }]
-  },
-  {
-    "name" : "Subscriptions R5 Backport",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.uv.subscriptions-backport",
-    "description" : "This guide defines a standard method of back-porting the R5 subscriptions API to R4 implementations as to bridge for pre-adopting R5 Subscriptions prior to adoption of the R5 FHIR standard.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/subscriptions-backport/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/subscriptions-backport",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-subscription-backport-ig",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "profiles" : 4,
-      "extensions" : 7,
-      "operations" : 2,
-      "valuesets" : 4,
-      "codeSystems" : 4,
-      "examples" : 9
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.2 Ballot",
-      "ig-version" : "1.2.0-ballot",
-      "package" : "hl7.fhir.uv.subscriptions-backport#1.2.0-ballot",
-      "fhir-version" : ["4.3.0"],
-      "url" : "http://hl7.org/fhir/uv/subscriptions-backport/2024Jan"
-    },
-    {
-      "name" : "STU 1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.uv.subscriptions-backport#1.1.0",
-      "fhir-version" : ["4.3.0"],
-      "url" : "http://hl7.org/fhir/uv/subscriptions-backport/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.subscriptions-backport#1.0.0",
-      "fhir-version" : ["4.3.0"],
-      "url" : "http://hl7.org/fhir/uv/subscriptions-backport/STU1"
-    }]
-  },
-  {
-    "name" : "Vital Records Birth and Fetal Death Reporting",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.bfdr",
-    "description" : "Provides guidance to implementers and states on reporting birth and fetal death information based on the current revisions of the U.S. Standard Certificate of Live Birth and U.S. Standard Report of Fetal Death.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/bfdr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/bfdr",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 49,
-      "extensions" : 6,
-      "valuesets" : 1,
-      "examples" : 137
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-bfdr",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.bfdr#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/bfdr/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.bfdr#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/bfdr/STU1.1"
-    },
-    {
-      "name" : "STU 1 on FHIR R4",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.bfdr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/bfdr/STU1"
-    }]
-  },
-  {
-    "name" : "Making EHR Data MOre available for Research and Public Health (MedMorph)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.medmorph",
-    "description" : "Making EHR Data More Available for Research and Public Health (MedMorph) Reference Architecture enables clinical data exchange between EHR systems, public health systems/authorities, data repositories, and research organizations.  This data exchange utilizes if applicable, knowledge repositories and backend services applications (e.g. FHIR APIs) to determine the triggering event(s) for the data exchange, the process for the data exchange, and validation that the data being exchanged meets a set of rules in order to expedite the data exchange. ",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/medmorph/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/medmorph",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-medmorph",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 13,
-      "extensions" : 9,
-      "operations" : 4,
-      "valuesets" : 4,
-      "codeSystems" : 5,
-      "examples" : 18
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Release 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.medmorph#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/medmorph/STU1"
-    }]
-  },
-  {
-    "name" : "SDOH Clinical Care for Multiple Domains",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.sdoh-clinicalcare",
-    "description" : "Profiles on FHIR R4 resources (using US Core as the basis where possible) used to document social determinants of health (SDOH) for an individual which covers many different factors considered social risks and social needs, e.g. Food Insecurity, Housing Stability and Quality, Transportation Access and others. The IG covers use cases identified from the clinical care setting that include : assessment of SDOH risks; evaluation of which risks can be addressed; setting goals,  documenting and tracking to completion SDOH interventions; and sharing SDOH information for an individual with organizations for secondary uses.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/sdoh-clinicalcare/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/sdoh-clinicalcare",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-sdoh-clinicalcare",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 9,
-      "valuesets" : 6,
-      "codeSystems" : 1,
-      "examples" : 31
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 3 Ballot",
-      "ig-version" : "3.0.0-ballot",
-      "package" : "hl7.fhir.us.sdoh-clinicalcare#3.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/sdoh-clinicalcare/2026Jan"
-    }]
-  },
-  {
-    "name" : "CDISC Mapping FHIR IG",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.cdisc-mapping",
-    "description" : "This implementation guide defines authoritative mappings between the CDISC LAB, SDTM and CDASH standards and the corresponding HL7 FHIR resources to ease interoperability and data conversion between systems implementing these standards.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cdisc-mapping/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cdisc-mapping",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cdisc-map",
-    "analysis" : {
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.cdisc-mapping#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cdisc-mapping/STU1"
-    }]
-  },
-  {
-    "name" : "NHSN Reporting of Adverse Drug Events - Hypoglycemia",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.nhsn-ade",
-    "description" : "US Realm IG providing guidance to implementers on reporting data elements to CDC's National Healthcare Safety Network (NHSN) related to inpatient blood glucose laboratory (including point-of-care) results and medication administration data (medications received during inpatient stay) based on FHIR resources. This IG addresses how inpatient EHR systems should format patient, blood glucose, and medication information to enable hospital reporting of these data to NHSN.  Query parameters are defined for each type of data element based on FHIR resources.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/nhsn-ade/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/nhsn-ade",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-nhsn-ade-ig/branches/main/index.html",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 3,
-      "examples" : 17
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 on FHIR R4",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.nhsn-ade#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/nhsn-ade/STU1"
-    }]
-  },
-  {
-    "name" : "NHSN Reporting: Inpatient Medication Administration",
-    "category" : "Surveillience / Reporting",
-    "npm-name" : "hl7.fhir.us.nhsn-med-admin",
-    "description" : "US Realm IG providing guidance to implementers on reporting data elements to CDC's National Healthcare Safety Network (NHSN) related to inpatient medication administration for hospitalized patients diagnosed with COVID-19, based on FHIR resources and as part of NHSN COVID-19 reporting pathways.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/nhsn-med-admin/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/nhsn-med-admin",
-    "ci-build" : "http://build.fhir.org/ig/HL7/nhsn-med-admin-ig/branches/main/index.html",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 5,
-      "examples" : 15
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 on FHIR R4",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.nhsn-med-admin#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/nhsn-med-admin/STU1"
-    }]
-  },
-  {
-    "name" : "HL7 Norway no-basis",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.no.basis",
-    "description" : "HL7 FHIR Base profiles for Norway",
-    "authority" : "HL7",
-    "product" : ["fhir"],
-    "country" : "no",
-    "language" : ["en"],
-    "canonical" : "http://hl7.no/fhir",
-    "editions" : [{
-      "name" : "HL7 Norway no-basis",
-      "ig-version" : "2.2.2",
-      "package" : "hl7.fhir.no.basis#2.2.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://simplifier.net/guide/no-basis-entities-individuals?version=current"
-    }],
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 20,
-      "extensions" : 13,
-      "valuesets" : 7,
-      "codeSystems" : 4
-    }
-  },
-  {
-    "name" : "Clinical Quality Language Specification",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.cql",
-    "description" : "Clinical Quality Language (CQL) is a high-level, domain-specific language focused on clinical quality and targeted at measure and decision support artifact authors. In addition, this specification describes a machine-readable canonical representation called Expression Logical Model (ELM) targeted at implementations and designed to enable sharing of clinical knowledge.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://cql.hl7.org/history.html",
-    "language" : ["en"],
-    "canonical" : "http://cql.hl7.org",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cql",
-    "analysis" : {
-      "error" : "Error reading http://cql.hl7.org/N1/package.tgz: null"
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "R2 STU 1",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.cql#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://cql.hl7.org/2025Sep"
-    }]
-  },
-  {
-    "name" : "Immunization Decision Support Forecast FHIR IG",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.immds",
-    "description" : "A common FHIR implementation guide that expert systems may use to provide a common consistent interface enable decisioin support recommending which vaccinations a patient is due for next",
-    "authority" : "HL7",
-    "country" : "us",
-    "language" : ["en"],
-    "history" : "http://hl7.org/fhir/us/immds/history.html",
-    "canonical" : "http://hl7.org/fhir/us/immds",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ImmunizationFHIRDS",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 4,
-      "operations" : 1,
-      "valuesets" : 4,
-      "codeSystems" : 3,
-      "examples" : 6
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.immds#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/immds/STU1"
-    }]
-  },
-  {
-    "name" : "Profiles for ICSR Transfusion and Vaccination Adverse Event Detection and Reporting",
-    "category" : "Pharmaceutical",
-    "npm-name" : "hl7.fhir.us.icsr-ae-reporting",
-    "description" : "This Implementation Guide provides a set of profiles and algorithms around the detection, validation, and reporting, as well as the eventual recording and persisting of Adverse Events associated with blood transfusions and vaccinations.  EHRs and Provider Networks can use this guide to understand the data elements needed to facilitate the electronic reporting of these adverse events as well as ways of mining their data to detect adverse events",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/icsr-ae-reporting/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/icsr-ae-reporting",
-    "ci-build" : "http://build.fhir.org/ig/HL7/icsr-ae-reporting",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "diagnostics" : true,
-      "profiles" : 22,
-      "extensions" : 20,
-      "valuesets" : 13,
-      "codeSystems" : 2,
-      "examples" : 42
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU Update",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.us.icsr-ae-reporting#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/icsr-ae-reporting/STU1"
-    }]
-  },
-  {
-    "name" : "Immunization Decision Support Forecast FHIR IG",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.uv.immds",
-    "description" : "The scope of this project is to produce and ballot a Standard for Trial Use (STU) Fast Healthcare Interoperability Resources (FHIR) implementation guide (IG) for use in Immunization Decision Support Forecast.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/immds/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/immds",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ImmunizationFHIRDS",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 3,
-      "operations" : 1
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.uv.immds#0.2.0",
-      "fhir-version" : ["4.0.0"],
-      "url" : "http://hl7.org/fhir/uv/immds/2019Sep"
-    }]
-  },
-  {
-    "name" : "Security for Scalable Registration, Authentication, and Authorization",
-    "category" : "Privacy / Security",
-    "npm-name" : "hl7.fhir.us.udap-security",
-    "description" : "This implementation guide describes how to extend OAuth 2.0 to support secure and scalable workflows for business-to-business (B2B) apps that implement the client credentials flow or authorization code flow. ",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/udap-security/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/udap-security",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-udap-security-ig",
-    "analysis" : {
-      "rest" : true
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.udap-security#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/udap-security/2025Jan"
-    },
-    {
-      "name" : "STU Update",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.udap-security#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/udap-security/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.udap-security#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/udap-security/STU1"
-    }]
-  },
-  {
-    "name" : "Single Institutional Review Board (sIRB) Implementation Guide",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.us.sirb",
-    "description" : "This IG covers questionnaires and questionnaire responses in support of capturing and exchange of standardized forms in support of a single IRB (Institutional Review Board) where a single IRB will expedite approval for a project but still need to send all documentation to multiple relying IRBs.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/sirb/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/sirb",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-sirb",
-    "analysis" : {
-      "codeSystems" : 1,
-      "examples" : 16
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.sirb#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/sirb/STU1"
-    }]
-  },
-  {
-    "name" : "Sharing eCC Data from Pathology Labs to EHR",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.us.cancer-reporting",
-    "description" : "Integrating the Healthcare Enterprise (IHE) Structured Data Capture (SDC) on FHIR uses a form-driven workflow to capture and transmit encoded data by creating FHIR Observations. The primary use case for this is transmitting data captured in College of American Pathologists electronic Cancer Checklists (eCCs), which are distributed as IHE SDC templates.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/cancer-reporting/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/cancer-reporting",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cancer-reporting",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "diagnostics" : true,
-      "profiles" : 6,
-      "valuesets" : 1,
-      "codeSystems" : 1,
-      "examples" : 27
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.cancer-reporting#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cancer-reporting/STU2"
-    }]
-  },
-  {
-    "name" : "HL7 FHIR® Implementation Guide: Ophthalmology Retinal, Release 1",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.eyecare",
-    "description" : "Provides representation of ophthalmic domain and related clinical and administrative data elements in the FHIR format to support effective collaborative and continuity of care of patients suffering from eye conditions. ",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/eyecare/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/eyecare",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-eyecare-ig",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "diagnostics" : true,
-      "profiles" : 15,
-      "valuesets" : 13,
-      "codeSystems" : 3,
-      "examples" : 32
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.uv.eyecare#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/eyecare/2021Sep"
-    }]
-  },
-  {
-    "name" : "SMART Health Cards Vaccination and Testing, Release 1 | STU 1",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.uv.shc-vaccination",
-    "description" : "Defines the clinical and patient information contained within a SMART Health Card (SHC) related to vaccination and lab results related to an infectious disease like COVID-19.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/shc-vaccination/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/shc-vaccination",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 16,
-      "valuesets" : 10,
-      "codeSystems" : 1
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.6.2",
-      "package" : "hl7.fhir.uv.shc-vaccination#0.6.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/shc-vaccination/2021Sep"
-    }]
-  },
-  {
-    "name" : "HL7 FHIR Implementation Guide for Military Service History and Status",
-    "category" : "Clinical Observations",
-    "npm-name" : "hl7.fhir.us.military-service",
-    "description" : "Supports Military Service History and Status reporting consistent with US regulatory requirements (i.e. Title 38 Veteran Benefits)",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/military-service/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/military-service",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-military-service",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 5,
-      "extensions" : 1,
-      "operations" : 1,
-      "valuesets" : 7,
-      "codeSystems" : 1,
-      "examples" : 5
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.military-service#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/military-service/STU1"
-    }]
-  },
-  {
-    "name" : "Taiwan Digital COVID-19 Certificate",
-    "category" : "Medication / Immunization",
-    "npm-name" : "dccfhirig.mohw.gov.tw",
-    "description" : "Taiwan Digital COVID-19 Certificate",
-    "authority" : "MOHW (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://dccfhirig.mohw.gov.tw/fhir/history.html",
-    "language" : ["en"],
-    "canonical" : "https://dccfhirig.mohw.gov.tw/ig",
-    "ci-build" : "https://dccfhirig.mohw.gov.tw/ig",
-    "editions" : [{
-      "name" : "DSTU 1",
-      "ig-version" : "1.1.1",
-      "package" : "dccfhirig.mohw.gov.tw#1.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://dccfhirig.mohw.gov.tw/ig"
-    }]
-  },
-  {
-    "name" : "Logica COVID-19 FHIR Profile Library IG",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.covid19library",
-    "description" : "Support for exchanges of COVD-19 Patient Specific Data.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/covid19library/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/covid19library",
-    "ci-build" : "http://build.fhir.org/ig/HL7/covid19library",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 146,
-      "extensions" : 4,
-      "valuesets" : 43,
-      "codeSystems" : 2,
-      "examples" : 141
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Informative Informative",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.covid19library#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/covid19library/informative1"
-    }]
-  },
-  {
-    "name" : "FHIR for FAIR - FHIR Implementation Guide",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.fhir-for-fair",
-    "description" : "The FHIR for FAIR Implementation Guide provides guidance on how the HL7 FHIR standard can be used for supporting the implementation and the assessment of the FAIR principles for health data",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/fhir-for-fair/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/fhir-for-fair",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-for-fair",
-    "analysis" : {
-      "error" : "Unsupported version: 4.1.0"
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.fhir-for-fair#1.0.0",
-      "fhir-version" : ["4.3.0"],
-      "url" : "http://hl7.org/fhir/uv/fhir-for-fair/STU1"
-    }]
-  },
-  {
-    "name" : "Da Vinci Patient Cost Transparency Implementation Guide",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-pct",
-    "description" : "Enables standard exchange of healthcare cost for items, services, and collection of services among stakeholders such as payers, providers, and patients in support of driving transparency for patients with accurate, timely access to cost of medical care prior to delivery of care in order to become better stewards of their healthcare dollars.   This guide creates a standard exchange to reduce administrative burden for communicating Good Faith Estimates (GFE) from providers of costs and services to payers and then, payers creating and returning an Advanced Explanation of Benefits (AEOB) back to the patient as required by law.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-pct/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/davinci-pct",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 11,
-      "extensions" : 17,
-      "operations" : 1,
-      "valuesets" : 18,
-      "codeSystems" : 14,
-      "examples" : 18
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-pct",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.1",
-      "package" : "hl7.fhir.us.davinci-pct#2.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pct/STU2.0.1"
-    }]
-  },
-  {
-    "name" : "Hybrid / Intermediary Exchange",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.us.exchange-routing",
-    "description" : "This IG is meant to define the standard for how providers, payers, intermediaries, and other actors will use  routing information about the transaction originator and destination to support a hybrid model of point-to-point interaction as well as intermediary brokered interactions without the actors in either side needing detailed knowledge of how intermediary routing works.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/exchange-routing/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/exchange-routing",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-exchange-routing-ig",
-    "analysis" : {
-      "rest" : true
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.exchange-routing#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/exchange-routing/STU1"
-    }]
-  },
-  {
-    "name" : "PACIO Re-Assessment Timepoints Implementation Guide",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.fhir.us.pacio-rt",
-    "description" : "The Re-assessment Timepoints FHIR implementation guide (IG) describes how to create definitions for sub-periods of time within an extended post-acute care (PAC) admission and encounter. ",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pacio-rt/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pacio-rt",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-pacio-rt",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 1,
-      "extensions" : 1,
-      "valuesets" : 4,
-      "codeSystems" : 3,
-      "examples" : 241
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.pacio-rt#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pacio-rt/STU1"
-    }]
-  },
-  {
-    "name" : "Da Vinci Risk Adjustment FHIR Implementation Guide",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-ra",
-    "description" : "Enable standard exchange of risk-based coding gaps among stakeholders such as payers, providers, and government care programs in support of driving towards accurate and complete documentation of health conditions that would lead to more accurate risk-adjustment payment calculations, reduced administrative burden, and improved quality of care.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-ra/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/davinci-ra",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-ra",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "measures" : true,
-      "profiles" : 4,
-      "extensions" : 6,
-      "operations" : 1,
-      "valuesets" : 3,
-      "codeSystems" : 3,
-      "examples" : 72
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.1.0",
-      "package" : "hl7.fhir.us.davinci-ra#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-ra/STU2.1"
-    }]
-  },
-  {
-    "name" : "International Patient Access",
-    "category" : "EHR Access",
-    "npm-name" : "hl7.fhir.uv.ipa",
-    "description" : "International Patient Access (IPA) defines a minimal, base set of FHIR profiles specifically intended to be used as-is, or built on top of by countries looking to enable patient access and patient-facing apps accessing data via FHIR",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ipa/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ipa",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-ipa",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 11,
-      "operations" : 1,
-      "examples" : 13
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.uv.ipa#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/ipa/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.ipa#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/ipa/STU1"
-    }]
-  },
-  {
-    "name" : "PACIO Advance Directive Information Implementation Guide",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.fhir.us.pacio-adi",
-    "description" : "The Advance Directive Interoperability (ADI) with FHIR implementation guide (IG) describes how to represent, exchange, and verify an individual's advance directive information regarding potential future care and treatment in the event the individual is not able to communicate such information directly.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pacio-adi/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pacio-adi",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "profiles" : 15,
-      "extensions" : 13,
-      "valuesets" : 17,
-      "codeSystems" : 2,
-      "examples" : 65
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-pacio-adi",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.pacio-adi#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pacio-adi/2025Sep"
-    }]
-  },
-  {
-    "name" : "CARIN Digital Insurance Card",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.insurance-card",
-    "description" : "This IG provides a structured approach to take the data elements on an individual consumer’s health insurance card and represent them using FHIR Resources (i.e., a 'Digital Insurance Card' Bundle). The IG also documents patterns to share Digital Insurance Cards via FHIR APIs, SMART Health Cards, and SMART Health Links. This information can be provided by the health insurance company and presented by the member as proof of insurance when interacting with healthcare providers. Eligibility checks are not in the scope of this IG",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/insurance-card/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/insurance-card",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "financials" : true,
-      "profiles" : 3,
-      "extensions" : 10,
-      "valuesets" : 5,
-      "codeSystems" : 5,
-      "examples" : 4
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/carin-digital-insurance-card",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.insurance-card#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/insurance-card/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.insurance-card#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/insurance-card/STU1"
-    }]
-  },
-  {
-    "name" : "Radiation Dose Summary for Diagnostic Procedures on FHIR",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.radiation-dose-summary",
-    "description" : "Provides a summary of the DICOM radiation dose report in FHIR related to imaging procedures.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/radiation-dose-summary/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/radiation-dose-summary",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-radiation-dose-summary-ig",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 9,
-      "valuesets" : 5,
-      "codeSystems" : 1,
-      "tests" : 3,
-      "examples" : 15
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.uv.radiation-dose-summary#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/radiation-dose-summary/2022Jan"
-    }]
-  },
-  {
-    "name" : "Making EHR Data MOre available for Research and Public Health (MedMorph) Central Cancer Registry Reporting Content IG",
-    "category" : "Public Health and Research",
-    "npm-name" : "hl7.fhir.us.central-cancer-registry-reporting",
-    "description" : "This guide defines how healthcare organizations onboard a new research data partner. It provides guidance to extract data from EHRs, transform the data, and populate data marts",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/central-cancer-registry-reporting/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/central-cancer-registry-reporting",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-central-cancer-registry-reporting",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "profiles" : 6,
-      "extensions" : 1,
-      "valuesets" : 1,
-      "examples" : 10
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.central-cancer-registry-reporting#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/central-cancer-registry-reporting/2026Jan"
-    }]
-  },
-  {
-    "name" : "Making EHR Data MOre available for Research and Public Health (MedMorph) Healthcare Surveys Reporting Content IG",
-    "category" : "Public Health and Research",
-    "npm-name" : "hl7.fhir.us.health-care-surveys-reporting",
-    "description" : "This guide focuses on the National Hospital Care Survey (NHCS) and National Ambulatory Medical Care Survey (NAMCS) data that will be extracted from EHRs and/or clinical data repositories via FHIR and APIs and sent to a system hosted at the federal level.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/health-care-surveys-reporting/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/health-care-surveys-reporting",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "carePlanning" : true,
-      "medsMgmt" : true,
-      "profiles" : 4,
-      "examples" : 13
-    },
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-health-care-surveys-reporting-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.health-care-surveys-reporting#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/health-care-surveys-reporting/STU2"
-    }]
-  },
-  {
-    "name" : "Making EHR Data MOre available for Research and Public Health (MedMorph) Research Content IG",
-    "category" : "Public Health and Research",
-    "npm-name" : "hl7.fhir.us.medmorph-research-dex",
-    "description" : "This guide focuses on the National Hospital Care Survey (NHCS) and National Ambulatory Medical Care Survey (NAMCS) data that will be extracted from EHRs and/or clinical data repositories via FHIR and APIs and sent to a system hosted at the federal level.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/medmorph-research-dex/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/medmorph-research-dex",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-medmorph-research-dex",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "carePlanning" : true,
-      "profiles" : 1,
-      "examples" : 6
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.us.medmorph-research-dex#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/medmorph-research-dex/2022Jan"
-    }]
-  },
-  {
-    "name" : "Medicolegal Death Investigation (MDI)",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.mdi",
-    "description" : "This US-specific IG supports exchange of data for medicolegal death investigations, for example from a toxicology lab to a case management system (upstream), and from a case management system to a  jurisdictional electronic death registration system (EDRS)(downstream).",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/mdi/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/mdi",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-mdi-ig",
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "diagnostics" : true,
-      "profiles" : 16,
-      "extensions" : 2,
-      "valuesets" : 7,
-      "codeSystems" : 2,
-      "examples" : 40
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.mdi#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mdi/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.mdi#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mdi/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.mdi#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mdi/STU1"
-    }]
-  },
-  {
-    "name" : "Clinical Quality Framework Common FHIR Assets",
-    "category" : "Quality / CDS",
-    "npm-name" : "fhir.cqf.common",
-    "description" : "This implementation guide contains common FHIR assets for use in CQFramework content IGs, including FHIRHelpers and the FHIR-ModelInfo libraries",
-    "authority" : "CQF",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://fhir.org/guides/cqf/common/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.org/guides/cqf/common",
-    "ci-build" : "http://build.fhir.org/ig/cqframework/cqf",
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "4.0.1",
-      "package" : "fhir.cqf.common#4.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.org/guides/cqf/common/4.0.1"
-    }],
-    "analysis" : {
-      "valuesets" : 2
-    }
-  },
-  {
-    "name" : "Maternal and Infant Health Research",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.mihr",
-    "description" : "This guide focuses on calculation of maternal-related cohorts from available maternal care information sources. It specifies how to calculate two maternal-related cohort measures and link to maternal longitudinal record with associated child record(s). Initial use cases focus on pregnancy and subsequent death within a specific time frame and hypertensive disorders of pregnancy pre, ante, and postpartum. The IG leverages MedMorph, SANER, US Core profiles, and broader public health IGs",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/mihr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/mihr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-mmm-ig",
-    "analysis" : {
-      "valuesets" : 9,
-      "examples" : 24
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.mihr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mihr/STU1"
-    }]
-  },
-  {
-    "name" : "Patient Request for Corrections Implementation Guide",
-    "category" : "Personal Healthcare",
-    "npm-name" : "hl7.fhir.uv.patient-corrections",
-    "description" : "The Patient Corrections FHIR implementation guide standardizes the method of electronically exchanging the required information to facilitate the patient’s request for corrections and the electronic communication that reflects the workflow of the correction process. ",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/patient-corrections/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/patient-corrections",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-patient-correction",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "carePlanning" : true,
-      "profiles" : 3,
-      "operations" : 1,
-      "valuesets" : 4,
-      "codeSystems" : 4,
-      "examples" : 17
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.patient-corrections#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/patient-corrections/STU1"
-    }]
-  },
-  {
-    "name" : "Interoperable Digital Identity and Patient Matching",
-    "category" : "Privacy / Security",
-    "npm-name" : "hl7.fhir.us.identity-matching",
-    "description" : "This FHIR implementation Guide provides guidance on leveraging Patient Matching and Digital Identity capabilities together to improve match quality and overall identity assurance in FHIR transactions. It defines methods to inform and execute cross organizational and internal patient matches via FHIR when requested for a permitted purpose or authorized by the Patient directly or by the Patient’s delegate. ",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/identity-matching/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/identity-matching",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-identity-matching-ig",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 3,
-      "valuesets" : 1,
-      "codeSystems" : 1,
-      "examples" : 3
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.identity-matching#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/identity-matching/2024SEP"
-    },
-    {
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.identity-matching#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/identity-matching/STU1"
-    }]
-  },
-  {
-    "name" : "CDC Opioid MME Calculator",
-    "category" : "Quality / CDS",
-    "npm-name" : "fhir.cdc.opioid-mme-r4",
-    "description" : "This implementation guide provides Morphine Milligram Equivalent (MME) calculation logic as described by the Centers For Disease Control and Prevention (CDC) Guideline for Prescribing Opioids for Chronic Pain — United States, 2016",
-    "authority" : "CQF",
-    "product" : ["fhir"],
-    "country" : "us",
-    "history" : "http://fhir.org/guides/cdc/opioid-mme-r4/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.org/guides/cdc/opioid-mme-r4",
-    "ci-build" : "http://build.fhir.org/ig/cqframework/opioid-mme-r4",
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "3.0.0",
-      "package" : "fhir.cdc.opioid-mme-r4#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.org/guides/cdc/opioid-mme-r4/3.0.0"
-    }],
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 1,
-      "codeSystems" : 3,
-      "examples" : 12
-    }
-  },
-  {
-    "name" : "FHIRcast",
-    "category" : "Imaging",
-    "npm-name" : "hl7.fhir.uv.fhircast",
-    "description" : "Following a SMART on FHIR launch, FHIRcast enables a SMART app to subscribe to a user's session, synchronizing with other healthcare applications. Using OAuth 2.0, websockets and a few simple events: EHRs, PACS, SMART apps and other systems show the same patient (or study) to the same user at the same time. In advanced imaging integrations, the FHIRcast websocket connection is re-used by synchronized apps to collaboratively create and exchange draft image measurements and similar findings.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/fhircast/history.html",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhircast-docs",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 2,
-      "extensions" : 1,
-      "examples" : 1
-    },
-    "canonical" : "http://fhircast.hl7.org",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU3 (v3.0.0)",
-      "ig-version" : "3.0.0",
-      "package" : "hl7.fhir.uv.fhircast#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhircast.hl7.org/STU3"
-    }]
-  },
-  {
-    "name" : "IHE Mobile Health Document Sharing (MHDS)",
-    "category" : "Clinical Documents",
-    "npm-name" : "ihe.iti.mhds",
-    "description" : "This Implementation Guide shows how to build a Document Sharing Exchange using IHE-profiled FHIR standard, rather than the legacy IHE profiles that are dominated by XDS and HL7 v2. This Implementation Guide assembles other IHE Implementation guides (Profiles) and defines a Document Registry Actor.",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "history" : "http://profiles.ihe.net/ITI/MHDS/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/MHDS",
-    "analysis" : {
-      "rest" : true
-    },
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.MHDS/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "2.3.1",
-      "package" : "ihe.iti.mhds#2.3.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/MHDS/2.3.1"
-    }]
-  },
-  {
-    "name" : "IHE Mobile Care Services Discovery (mCSD)",
-    "category" : "Administration",
-    "npm-name" : "ihe.iti.mcsd",
-    "description" : "The IHE Mobile Care Services Discovery (mCSD) IG provides a transaction for mobile and lightweight browser-based applications to find and update care services resources.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "http://profiles.ihe.net/ITI/mCSD/history.html",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.mCSD/branches/main",
-    "canonical" : "https://profiles.ihe.net/ITI/mCSD",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "profiles" : 14,
-      "extensions" : 2,
-      "valuesets" : 3,
-      "codeSystems" : 3,
-      "examples" : 21
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "4.0.0",
-      "package" : "ihe.iti.mcsd#4.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/mCSD/4.0.0"
-    }]
-  },
-  {
-    "name" : "Pan-Canadian Patient Summary",
-    "category" : "Patient Summary",
-    "npm-name" : "ca.infoway.io.psca",
-    "description" : "The Pan-Canadian Patient Summary (PS-CA) IG and accompanying [PS-CA specification](https://infoscribe.infoway-inforoute.ca/pages/viewpage.action?pageId=149160290) adapt the HL7 [International Patient Summary](http://hl7.org/fhir/uv/ips/) (IPS) for use in a Canadian context.",
-    "authority" : "Canada Health Infoway",
-    "product" : ["fhir"],
-    "country" : "ca",
-    "history" : "https://simplifier.net/PS-CA-R1/~guides",
-    "language" : ["en"],
-    "canonical" : "http://fhir.infoway-inforoute.ca/io/psca",
-    "ci-build" : "https://simplifier.net/PS-CA-R1",
-    "editions" : [{
-      "name" : "Trial Implementation",
-      "ig-version" : "1.0.0",
-      "package" : "ca.infoway.io.psca#1.0.0-pre",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://packages.simplifier.net/ca.infoway.io.psca/1.0.0-pre"
-    },
-    {
-      "name" : "Public Comment 0.3",
-      "ig-version" : "0.3.0",
-      "package" : "ca.infoway.io.psca#0.3.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://packages.simplifier.net/ca.infoway.io.psca/0.3.2"
-    },
-    {
-      "name" : "Public Comment 0.2",
-      "ig-version" : "0.0.4",
-      "package" : "ca.infoway.io.psca#0.0.4",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://packages.simplifier.net/ca.infoway.io.psca/0.0.4"
-    },
-    {
-      "name" : "Public Comment 0.1",
-      "ig-version" : "0.0.3",
-      "package" : "ca.infoway.vc.ps#0.0.3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://packages.simplifier.net/ca.infoway.vc.ps/0.0.3"
-    }],
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 19,
-      "extensions" : 3,
-      "valuesets" : 24,
-      "codeSystems" : 1
-    }
-  },
-  {
-    "name" : "Canadian Baseline",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.ca.baseline",
-    "description" : "Base Canadian national implementation guide",
-    "authority" : "HL7 Canada",
-    "product" : ["fhir"],
-    "country" : "ca",
-    "history" : "https://simplifier.net/canadianfhirbaselineprofilesca-core",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/ca/baseline",
-    "ci-build" : "https://build.fhir.org/ig/HL7-Canada/ca-baseline",
-    "editions" : [{
-      "name" : "Public Comment",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.ca.baseline#1.1.3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://packages.simplifier.net/hl7.fhir.ca.baseline/1.1.3"
-    },
-    {
-      "name" : "Public Comment",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.ca.baseline#1.0.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://packages.simplifier.net/hl7.fhir.ca.baseline/1.0.2"
-    }],
-    "analysis" : {
-      "content" : true,
-      "documents" : true,
-      "clinicalCore" : true,
-      "medsMgmt" : true,
-      "profiles" : 31,
-      "extensions" : 13,
-      "valuesets" : 9,
-      "codeSystems" : 2
-    }
-  },
-  {
-    "name" : "IHE Mobile Access to Health Documents (MHD)",
-    "category" : "EHR Access",
-    "npm-name" : "ihe.iti.mhd",
-    "description" : "Defines a simple HTTP interface to a Document Sharing environment, including: publishing/query (XDS-on-FHIR), point-to-point push (XDR, Direct, XDM), and federation of communities (XCA).",
-    "authority" : "IHE",
-    "country" : "uv",
-    "language" : ["en"],
-    "history" : "https://profiles.ihe.net/ITI/MHD/history.html",
-    "canonical" : "https://profiles.ihe.net/ITI/MHD",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.MHD",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "documents" : true,
-      "profiles" : 24,
-      "extensions" : 4,
-      "valuesets" : 3,
-      "codeSystems" : 1,
-      "examples" : 48
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "FHIR R5",
-      "ig-version" : "5.0.0",
-      "package" : "ihe.iti.mhd#5.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://profiles.ihe.net/ITI/MHD/5.0.0"
-    }]
-  },
-  {
-    "name" : "IHE Basic Audit Log Patterns (BALP)",
-    "category" : "Privacy / Security",
-    "npm-name" : "ihe.iti.balp",
-    "description" : "The Basic Audit Log Patterns (BALP) **Content Profile** defines some basic and reusable AuditEvent patterns. This includes basic audit log profiles for FHIR RESTful operations, to be used when there is not a more specific audit event defined. Where a more specific audit event can be defined it should be derived off of these basic patterns.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/BALP/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/BALP",
-    "analysis" : {
-      "content" : true,
-      "profiles" : 20,
-      "extensions" : 2,
-      "valuesets" : 6,
-      "codeSystems" : 5,
-      "examples" : 63
-    },
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.BasicAudit/branches/main/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.1.4",
-      "package" : "ihe.iti.balp#1.1.4",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/BALP/1.1.4"
-    }]
-  },
-  {
-    "name" : "IHE Interactive Multimedia Report (IMR)",
-    "category" : "Imaging",
-    "npm-name" : "ihe.rad.imr",
-    "description" : "Support encoding and presentation of an interactive multimedia report",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/RAD/IMR/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/RAD/IMR",
-    "ci-build" : "http://build.fhir.org/ig/IHE/RAD.IMR",
-    "analysis" : {
-      "content" : true,
-      "rest" : true,
-      "clinicalCore" : true,
-      "diagnostics" : true,
-      "profiles" : 8,
-      "extensions" : 2,
-      "valuesets" : 7,
-      "examples" : 19
-    },
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.1.0",
-      "package" : "ihe.rad.imr#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/RAD/IMR/1.1.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Core profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.core",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Core profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/core/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/core",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/core",
-    "editions" : [{
-      "name" : "Trial Use Test",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.be.core#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/core/2.0.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "2.0.1",
-      "package" : "hl7.fhir.be.core#2.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/core/2.0.1"
-    }]
-  },
-  {
-    "name" : "eHealth FHIR Patient Care Profiles for Belgium",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.patient-care",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Prescription Search Support profiles",
-    "authority" : "eHealth Platform",
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/patient-care/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/patient-care",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/patient-care",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.patient-care#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/patient-care/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Prescription Search Support profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.pss",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Prescription Search Support profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/pss/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/pss",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/pss",
-    "editions" : [{
-      "name" : "Trial Use Test",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.pss#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/pss/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Digital Referral Prescription profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.drp",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Digital Referral Prescription profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/drp/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/drp",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/referral",
-    "editions" : [{
-      "name" : "Trial Use Test",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.drp#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/drp/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Patient Dossier profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.patient-dossier",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Patient Dossier profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/patient-dossier/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/patient-dossier",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/patient-dossier",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.patient-dossier#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/patient-dossier/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Core clinical profiles - transversal",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.core-clinical",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Core clinical profiles - transversal",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/core-clinical/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/core-clinical",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/core-clinical",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.core-clinical#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/core-clinical/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Medication profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.medication",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Medication profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/medication/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/medication",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/medication",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.medication#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/medication/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Vaccination profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.vaccination",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Vaccination profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/vaccination/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/vaccination",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/vaccination",
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 6,
-      "extensions" : 1,
-      "valuesets" : 3,
-      "codeSystems" : 5,
-      "examples" : 6
-    },
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.vaccination#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.be.vaccination#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.1"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.0.2",
-      "package" : "hl7.fhir.be.vaccination#1.0.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.2"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.0.3",
-      "package" : "hl7.fhir.be.vaccination#1.0.3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/vaccination/1.0.3"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - MyCareNet profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.mycarenet",
-    "description" : "HL7 Belgium FHIR Implementation Guide - MyCareNet profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/mycarenet/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/mycarenet",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/mycarenet",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.be.mycarenet#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/mycarenet/2.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Lab related profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.lab",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Lab related profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/lab/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/lab",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/lab",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.lab#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/lab/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Belgium FHIR Implementation Guide - Allergy profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.allergy",
-    "description" : "HL7 Belgium FHIR Implementation Guide - Allergy profiles",
-    "authority" : "eHealth Platform (BE)",
-    "product" : ["fhir"],
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/allergy/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/allergy",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/allergy",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.allergy#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/allergy/1.0.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.be.allergy#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/allergy/1.0.1"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.be.allergy#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/allergy/1.1.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.2.0",
-      "package" : "hl7.fhir.be.allergy#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/allergy/1.2.0"
-    }]
-  },
-  {
-    "name" : "eHealth FHIR Patient Will Profiles for Belgium",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.patientwill",
-    "description" : "eHealth FHIR Patient Will Profiles for Belgium",
-    "authority" : "eHealth Platform (BE)",
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/patientwill/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/patientwill",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/patientwill",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.patientwill#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/patientwill/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "TW Core",
-    "category" : "National Base",
-    "npm-name" : "tw.gov.mohw.twcore",
-    "description" : "Taiwan Core Implementation Guide",
-    "authority" : "MOHW (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://twcore.mohw.gov.tw/ig/twcore/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://twcore.mohw.gov.tw/ig/twcore",
-    "ci-build" : "https://build.fhir.org/ig/TU9IVy1UV0NvcmVJRw/VFcgQ29yZSBJRyBJVFJJ",
-    "editions" : [{
-      "name" : "STU 1.0.0",
-      "ig-version" : "1.0.0",
-      "package" : "tw.gov.mohw.twcore#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://twcore.mohw.gov.tw/ig/twcore/1.0.0"
-    }]
-  },
-  {
-    "name" : "TWIDIR",
-    "category" : "Medication / Immunization",
-    "npm-name" : "tw.gov.mohw.cdc.twidir",
-    "description" : "Taiwan Infectious Disease Inspection Report Implementation Guide",
-    "authority" : "CDC (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://twidir.cdc.gov.tw/twidir/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://twidir.cdc.gov.tw/twidir",
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.4.0",
-      "package" : "tw.gov.mohw.cdc.twidir#1.4.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://twidir.cdc.gov.tw/twidir/1.4.0"
-    }]
-  },
-  {
-    "name" : "EMR",
-    "category" : "Clinical Observations",
-    "npm-name" : "tw.gov.mohw.emr",
-    "description" : "Taiwan EMR Implementation Guide",
-    "authority" : "MOHW (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://twcore.mohw.gov.tw/ig/emr/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://twcore.mohw.gov.tw/ig/emr",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "0.2.0",
-      "package" : "tw.gov.mohw.emr#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://twcore.mohw.gov.tw/ig/emr/0.2.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "0.1.0",
-      "package" : "tw.gov.mohw.emr#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://twcore.mohw.gov.tw/ig/emr/0.1.0"
-    }]
-  },
-  {
-    "name" : "TWPAS",
-    "category" : "Financial",
-    "npm-name" : "tw.gov.mohw.nhi.pas",
-    "description" : "Taiwan NHI Cancer Prior Authorization Support Implementation Guide",
-    "authority" : "NHIA (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://nhicore.nhi.gov.tw/pas/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://nhicore.nhi.gov.tw/pas",
-    "ci-build" : "https://build.fhir.org/ig/TWNHIFHIR/pas",
-    "editions" : [{
-      "name" : "STU1.1.1",
-      "ig-version" : "1.1.1",
-      "package" : "tw.gov.mohw.nhi.pas#1.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://nhicore.nhi.gov.tw/pas/1.1.1"
-    }]
-  },
-  {
-    "name" : "TWNGS",
-    "category" : "Clinical Documents",
-    "npm-name" : "tw.gov.mohw.nhi.ngs",
-    "description" : "Taiwan NHI Next Generation Sequencing Implementation Guide",
-    "authority" : "NHIA (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://nhicore.nhi.gov.tw/ngs/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://nhicore.nhi.gov.tw/ngs",
-    "ci-build" : "https://build.fhir.org/ig/TWNHIFHIR/ngs",
-    "editions" : [{
-      "name" : "STU1.0.0",
-      "ig-version" : "1.0.0",
-      "package" : "tw.gov.mohw.nhi.ngs#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://nhicore.nhi.gov.tw/ngs/1.0.0"
-    }]
-  },
-  {
-    "name" : "TWCI",
-    "category" : "Administration",
-    "npm-name" : "tw.gov.mohw.nhi.ci",
-    "description" : "Taiwan NHI Catastrophic Illness Implementation Guide",
-    "authority" : "NHIA (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://nhicore.nhi.gov.tw/ci/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://nhicore.nhi.gov.tw/ci",
-    "ci-build" : "https://build.fhir.org/ig/TWNHIFHIR/ci",
-    "editions" : [{
-      "name" : "STU1.0.1",
-      "ig-version" : "1.0.1",
-      "package" : "tw.gov.mohw.nhi.ci#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://nhicore.nhi.gov.tw/ci/1.0.1"
-    }]
-  },
-  {
-    "name" : "EMPD",
-    "category" : "Medication",
-    "npm-name" : "tw.gov.mohw.nhi.empd",
-    "description" : "Taiwan Electronic Medication Prescription and Dispense Implementation Guide",
-    "authority" : "NHIA (TW)",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://nhicore.nhi.gov.tw/empd/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://nhicore.nhi.gov.tw/empd",
-    "editions" : [{
-      "name" : "STU0.1.0",
-      "ig-version" : "0.1.0",
-      "package" : "tw.gov.mohw.nhi.empd#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://nhicore.nhi.gov.tw/empd/0.1.0"
-    }]
-  },
-  {
-    "name" : "IClaim",
-    "category" : "Financial",
-    "npm-name" : "tw.cathay.fhir.iclaim",
-    "description" : "Guidelines for Medical Insurance Claims Implementation",
-    "authority" : "國泰綜合醫院",
-    "product" : ["fhir"],
-    "country" : "tw",
-    "history" : "https://claim.cgh.org.tw/iclaim/history.html",
-    "language" : ["zh-TW"],
-    "canonical" : "https://claim.cgh.org.tw/iclaim",
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "tw.cathay.fhir.iclaim#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://claim.cgh.org.tw/iclaim/1.0.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "0.1.3",
-      "package" : "tw.cathay.fhir.iclaim#0.1.3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://claim.cgh.org.tw/iclaim/0.1.3"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "0.1.2",
-      "package" : "tw.cathay.fhir.iclaim#0.1.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://claim.cgh.org.tw/iclaim/0.1.2"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "0.1.1",
-      "package" : "tw.cathay.fhir.iclaim#0.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://claim.cgh.org.tw/iclaim/0.1.1"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "0.1.0",
-      "package" : "tw.cathay.fhir.iclaim#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://claim.cgh.org.tw/iclaim/0.1.0"
-    }]
-  },
-  {
-    "name" : "CodeX™ Radiation Therapy",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.codex-radiation-therapy",
-    "description" : "The CodeX Radiation Therapy (RT) Implementation Guide (IG) describes how to represent and exchange radiation therapy treatment information. The CodeX RT IG enables radiation oncology information systems to generate treatment summaries that are retrievable by health systems, or other information systems, for display within the EHR interface to be used for care coordination and data reuse. ",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/codex-radiation-therapy/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/codex-radiation-therapy",
-    "ci-build" : "http://build.fhir.org/ig/codex-radiation-therapy",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.codex-radiation-therapy#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/codex-radiation-therapy/STU2"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.codex-radiation-therapy#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/codex-radiation-therapy/STU1"
-    }]
-  },
-  {
-    "name" : "At-Home In-Vitro Test Report",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.fhir.us.home-lab-report",
-    "description" : "This Implementation Guide describes a framework for use for transmitting At-Home Point-of-Care lab test results to local, state, territorial and federal health agencies. This version also contains workflow description and profiles and vocabulary for transmitting Covid-At-Home tests.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/home-lab-report/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/home-lab-report",
-    "ci-build" : "http://build.fhir.org/ig/HL7/home-lab-report",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.home-lab-report#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/home-lab-report/STU1.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.home-lab-report#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/home-lab-report/STU1"
-    }]
-  },
-  {
-    "name" : "PACIO Personal Functioning and Engagement Implementation Guide",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.fhir.us.pacio-pfe",
-    "description" : "The Personal Functioning and Engagement IG provides a framework for communicating the functioning of an individual, including their body functions and structure and their activities and participation in society, as well as related clinical care. The IG draws on the health and health-related domains defined within the International Classification of Functioning, Disability and Health (commonly known as ICF).",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pacio-pfe/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pacio-pfe",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-pacio-pfe",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.pacio-pfe#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pacio-pfe/STU2"
-    }]
-  },
-  {
-    "name" : "US Public Health Profiles Library",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.ph-library",
-    "description" : "The US Public Health Profiles Library is a collection of reusable architecture and content profiles representing common public health concepts and patterns. It provides a framework for inclusion in multiple use case specific implementation guides focused on the exchange of Public Health information.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/ph-library/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/ph-library",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-us-ph-library",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.ph-library#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ph-library/STU2"
-    }]
-  },
-  {
-    "name" : "National Healthcare Query",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.us.directory-query",
-    "description" : "Standard for endpoint query request and response for Validated National Directory federated access directories",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/directory-query/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/directory-query",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-directory-query",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.directory-query#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/directory-query/2022Sep"
-    }]
-  },
-  {
-    "name" : "National Healthcare Directory Exchange",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.us.directory-exchange",
-    "description" : "Standard for exchange of Health and Social Care Directory information between a Validated National Directory and a federated directory (primarily for workflow integration).",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/directory-exchange/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/directory-exchange",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-directory-exchange",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.directory-exchange#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/directory-exchange/2022Sep"
-    }]
-  },
-  {
-    "name" : "National Healthcare Directory Attestation",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.us.directory-attestation",
-    "description" : "Provides the methods and standards for the contribution, attestation, and validation of information in the National Directory.  This applies to individual demographics, organizational demographics, relationship between individuals and organizations, services provided, and electronic endpoint metadata.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/directory-attestation/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/directory-attestation",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-directory-attestation",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.directory-attestation#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/directory-attestation/2022Sep"
-    }]
-  },
-  {
-    "name" : "Sharing Valuesets, Codes, and Maps (SVCM)",
-    "category" : "Terminology",
-    "npm-name" : "ihe.iti.svcm",
-    "description" : "The Sharing Valuesets, Codes, and Maps (SVCM) Profile defines a lightweight interface through which healthcare systems may retrieve centrally managed uniform nomenclature and mappings between code systems based on the HL7 Fast Healthcare Interoperability Resources (FHIR) specification.",
-    "authority" : "IHE",
-    "product" : ["fhir"],
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/SVCM/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/SVCM",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.SVCM",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.5.1",
-      "package" : "ihe.iti.svcm#1.5.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/SVCM/1.5.1"
-    }]
-  },
-  {
-    "name" : "IHE SDC/eCC on FHIR",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.ihe-sdc-ecc",
-    "description" : "Integrating the Healthcare Enterprise (IHE) Structured Data Capture (SDC) on FHIR uses a form-driven workflow to capture and transmit encoded data by creating FHIR Observations. The primary use case for this is transmitting data captured in College of American Pathologists electronic Cancer Checklists (eCCs), which are distributed as IHE SDC templates.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ihe-sdc-ecc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ihe-sdc-ecc",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.ihe-sdc-ecc#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/ihe-sdc-ecc/STU1"
-    }]
-  },
-  {
-    "name" : "Vital Signs FHIR IG",
-    "category" : "Clinical Observations",
-    "npm-name" : "hl7.fhir.us.vitals",
-    "description" : "US Realm Implementation Guide for Vital Signs observations with extensions for qualifying data.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/vitals/history.html",
-    "canonical" : "http://hl7.org/fhir/us/vitals",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cimi-vital-signs",
-    "language" : ["en"],
-    "analysis" : {
-      "content" : true,
-      "clinicalCore" : true,
-      "profiles" : 15,
-      "extensions" : 11,
-      "valuesets" : 27,
-      "codeSystems" : 3,
-      "examples" : 15
-    },
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.vitals#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/vitals/STU1"
-    }]
-  },
-  {
-    "name" : "HL7 Cross Paradigm IG: Gender Harmony - Sex and Gender Representation",
-    "category" : "Administration",
-    "npm-name" : "hl7.xprod.uv.gender-harmony",
-    "description" : "Provide profile components and guidance on how to properly represent Gender Identity as distinct from clinical sex characterization via Sex For Clinical Use, as well as other aligned sex- or gender-related data elements (Recorded Sex or Gender, Name to Use, Pronouns, etc.) Covers implementation approaches for FHIR, CDA, and V2.",
-    "authority" : "HL7",
-    "product" : ["fhir", "cda", "v2"],
-    "country" : "uv",
-    "history" : "http://hl7.org/xprod/ig/uv/gender-harmony/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/xprod/ig/uv/gender-harmony",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-gender-harmony",
-    "editions" : [{
-      "name" : "Informative Edition 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.xprod.uv.gender-harmony#1.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/xprod/ig/uv/gender-harmony/informative1"
-    }]
-  },
-  {
-    "name" : "HL7 UK FHIR UKCore Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "fhir.r4.ukcore.stu3.currentbuild",
-    "description" : "HL7 UK FHIR UKCore Implementation Guide",
-    "authority" : "HL7 UK",
-    "country" : "gb",
-    "history" : "https://simplifier.net/guide/ukcoreversionhistory/home?version=current",
-    "language" : ["en"],
-    "canonical" : "https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence?version=current",
-    "editions" : [{
-      "name" : "STU 3",
-      "ig-version" : "0.0.18-pre-release",
-      "package" : "fhir.r4.ukcore.stu3.currentbuild 0.0.18-pre-release",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://simplifier.net/guide/UK-Core-Implementation-Guide-STU3-Sequence/Home?version=current"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.1",
-      "package" : "fhir.r4.ukcore.stu2 2.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://simplifier.net/guide/uk-core-implementation-guide-stu2?version=2.0.1"
-    },
-    {
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "fhir.r4.ukcore.stu1 1.0.4",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://simplifier.net/guide/uk-core-implementation-guide?version=1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Electronic Medicinal Product Information (ePI) FHIR Implementation Guide",
-    "category" : "Pharmaceutical Mgmt",
-    "npm-name" : "hl7.fhir.uv.emedicinal-product-info",
-    "description" : "This guide provides best practice guidance for creating and representing electronic product information for medicinal products.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/emedicinal-product-info/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/emedicinal-product-info",
-    "ci-build" : "http://build.fhir.org/ig/HL7/emedicinal-product-info",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.emedicinal-product-info#1.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/emedicinal-product-info/STU1"
-    }]
-  },
-  {
-    "name" : "Retrieval of Real World Data for Clinical Research",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.vulcan-rwd",
-    "description" : "This IG provides profiles that define the data needed from EHRs to answer research questions arising from clinical studies.  It will demonstrate how FHIR and EHRs can directly support clinical trials.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/vulcan-rwd/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/vulcan-rwd",
-    "ci-build" : "http://build.fhir.org/ig/HL7/vulcan-rwd",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.vulcan-rwd#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/vulcan-rwd/STU1"
-    }]
-  },
-  {
-    "name" : "MCC eCare Plan Implementation Guide",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.mcc",
-    "description" : "Provides representation of clinical and social data elements in the FHIR Care Plan format. Focuses on 4 common chronic conditions: 1) chronic kidney disease (CKD), 2) type 2 diabetes mellitus (T2DM), 3) cardiovascular diseases (specifically, hypertension, ischemic heart disease and heart failure), and 4) pain.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/mcc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/mcc",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-us-mcc",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.mcc#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/mcc/STU1"
-    }]
-  },
-  {
-    "name" : "Clinical Study Schedule of Activities",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.vulcan-schedule",
-    "description" : "This guide provides best practice guidance for representing the schedule of activities (visits/encounters) in a Research Study and for relating EHR data to that schedule.  It also includes definition of blocks of standard activities that can subsequently be used as components of studies.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/vulcan-schedule/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/vulcan-schedule",
-    "ci-build" : "http://build.fhir.org/ig/HL7/Vulcan-schedule-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.vulcan-schedule#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/vulcan-schedule/STU1"
-    }]
-  },
-  {
-    "name" : "EHRS Functional Model - Record Lifecycle Events Implementation Guide",
-    "category" : "Mappings to Other Standards",
-    "npm-name" : "hl7.fhir.uv.ehrs-rle",
-    "description" : "This implementation guide describes the expected capabilities for an Electronic Health Record System (EHR-S) that intends to adhere to the ISO/HL7 10781 Electronic Health Record System Functional Model Release 2 which covers the logging of record lifecycle events.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ehrs-rle/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ehrs-rle",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ehrs-rle-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Informative Release 1 Informative",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.uv.ehrs-rle#1.1.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/ehrs-rle/Informative1"
-    }]
-  },
-  {
-    "name" : "ICHOM breast cancer patient-centered outcome measure set FHIR IG",
-    "category" : "Quality / CDS",
-    "npm-name" : "hl7.fhir.uv.ichom-breast-cancer",
-    "description" : "This Implementation Guide describes the representation of the ICHOM Breast Cancer Patient Centered Outcomes Measures in HL7 FHIR and a description of the use cases for which these are be intended to be used.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ichom-breast-cancer/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ichom-breast-cancer",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-ichom-breast-cancer-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.ichom-breast-cancer#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/ichom-breast-cancer/STU1"
-    }]
-  },
-  {
-    "name" : "FHIR IG Human Services Directory",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.hsds",
-    "description" : "FHIR API-based data exchange enabling healthcare provider, community-based organization, payer, and consumer-facing application systems to search standardized directories of organizations providing human and social services, providing foundational support for downstream care planning and management use cases, including closed loop referrals, care coordination and care management activities, consumer-based search for assistance, etc. This guide is a US Realm specification.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/hsds/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/hsds",
-    "ci-build" : "http://build.fhir.org/ig/HL7/FHIR-IG-Human-Services-Directory",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.hsds#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/hsds/STU1"
-    }]
-  },
-  {
-    "name" : "DK MedCom CareCommunication",
-    "category" : "Care Management",
-    "npm-name" : "medcom.fhir.dk.carecommunication",
-    "description" : "This IG includes profiles used in MedCom's CareCommunication standard. The purpose of CareCommunication is to support messagebased, digital communication between parties within Danish healthcare and the social area.",
-    "authority" : "MedCom (DK)",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/carecommunication/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/carecommunication",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-carecommunication",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "3.0.0",
-      "package" : "medcom.fhir.dk.carecommunication#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/carecommunication/3.0.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.0.0",
-      "package" : "medcom.fhir.dk.carecommunication#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/carecommunication/2.0.0"
-    },
-    {
-      "name" : "STU",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.carecommunication#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/fhir/ig/dk-medcom-carecommunication"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "DK MedCom Core",
-    "category" : "Frameworks",
-    "npm-name" : "medcom.fhir.dk.core",
-    "description" : "This IG includes core profiles defined by MedCom. These profiles are used in MedCom's FHIR standards.",
-    "authority" : "MedCom (DK)",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/core/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/core",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-core",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "2.3.0",
-      "package" : "medcom.fhir.dk.core#2.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/core/2.3.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.2.0",
-      "package" : "medcom.fhir.dk.core#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/core/2.2.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.1.0",
-      "package" : "medcom.fhir.dk.core#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/core/2.1.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.0.0",
-      "package" : "medcom.fhir.dk.core#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/core/2.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "DK MedCom Terminology",
-    "category" : "Terminology",
-    "npm-name" : "medcom.fhir.dk.terminology",
-    "description" : "This IG includes CodeSystems, ValueSets and ConceptMaps defined by MedCom and used in MedCom's FHIR standards.",
-    "authority" : "MedCom (DK)",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/terminology/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/terminology",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-terminology",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.6.0",
-      "package" : "medcom.fhir.dk.terminology#1.6.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.6.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.5.0",
-      "package" : "medcom.fhir.dk.terminology#1.5.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.5.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.4.0",
-      "package" : "medcom.fhir.dk.terminology#1.4.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.4.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.3.0",
-      "package" : "medcom.fhir.dk.terminology#1.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.3.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.2.0",
-      "package" : "medcom.fhir.dk.terminology#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.2.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.1.1",
-      "package" : "medcom.fhir.dk.terminology#1.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.1.1"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.1.0",
-      "package" : "medcom.fhir.dk.terminology#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.1.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.terminology#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/terminology/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "DK MedCom HospitalNotification",
-    "category" : "Care Management",
-    "npm-name" : "medcom.fhir.dk.hospitalnotification",
-    "description" : "This IG includes profiles used in MedCom's HospitalNotification standard. The purpose of HospitalNotification is to inform the citizen’s current care and health provider in the primary sector about the start, end, and period of leave of the citizen’s stay at the hospital. The communication is messagebased.",
-    "authority" : "MedCom (DK)",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/hospitalnotification/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/hospitalnotification",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-hospitalnotification",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "3.0.1",
-      "package" : "medcom.fhir.dk.hospitalnotification#3.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/hospitalnotification/3.0.1"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "3.0.0",
-      "package" : "medcom.fhir.dk.hospitalnotification#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/hospitalnotification/3.0.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.0.0",
-      "package" : "medcom.fhir.dk.hospitalnotification#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/hospitalnotification/2.0.0"
-    },
-    {
-      "name" : "STU",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.hospitalnotification#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/fhir/ig/dk-medcom-hospitalnotification"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "DK MedCom Acknowledgement",
-    "category" : "Frameworks",
-    "npm-name" : "medcom.fhir.dk.acknowledgement",
-    "description" : "This IG includes profiles used in MedCom's Acknowledgement standard. An Acknowledgement is used as a receipt in messagebased communication.",
-    "authority" : "MedCom (DK)",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/acknowledgement/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/acknowledgement",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-acknowledgement",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "2.0.1",
-      "package" : "medcom.fhir.dk.acknowledgement#2.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/acknowledgement/2.0.1"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.0.0",
-      "package" : "medcom.fhir.dk.acknowledgement#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/acknowledgement/2.0.0"
-    },
-    {
-      "name" : "STU",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.acknowledgement#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/fhir/ig/dk-medcom-acknowledgement"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "DK MedCom HomeCareObservation",
-    "category" : "Care Management",
-    "npm-name" : "medcom.fhir.dk.homecareobservation",
-    "description" : "This Implementation Guide contains profiles developed to be part of a production trial of the communication between the general practitioner and municipal acute care team.      ",
-    "authority" : "MedCom",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/homecareobservation/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/homecareobservation",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-homecareobservation",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.homecareobservation#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/homecareobservation/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "DK MedCom Messaging",
-    "category" : "Frameworks",
-    "npm-name" : "medcom.fhir.dk.messaging",
-    "description" : "This IG includes messaging profiles defined by MedCom. These profiles are used in messagebased communication.",
-    "authority" : "MedCom (DK)",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/messaging/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/messaging",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-messaging",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "2.1.0",
-      "package" : "medcom.fhir.dk.messaging#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/messaging/2.1.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "2.0.0",
-      "package" : "medcom.fhir.dk.messaging#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/messaging/2.0.0"
-    },
-    {
-      "name" : "STU",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.messaging#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/fhir/ig/dk-medcom-messaging"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "CDA: Clinical Document Architecture",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.cda.uv.core",
-    "description" : "This Implementation Guide is a representation of the Clinical Document Architecture (CDA) specification using FHIR Logical Models expressed as FHIR StructureDefinition instances.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/cda/stds/core/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/cda/stds/core",
-    "ci-build" : "http://build.fhir.org/ig/HL7/CDA-core-sd",
-    "product" : ["fhir", "cda"],
-    "editions" : [{
-      "name" : "CDA 2.0 Informative",
-      "ig-version" : "2.0.2-sd",
-      "package" : "hl7.cda.uv.core#2.0.2-sd",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/cda/stds/core/2.0.2-sd"
-    }]
-  },
-  {
-    "name" : "Integrated Reporting Applications",
-    "category" : "Imaging",
-    "npm-name" : "ihe.rad.ira",
-    "description" : "The Integrated Reporting Applications (IRA) profile helps applications that are used together during reporting (e.g., image display, report creator, clinical applications, AI tools, etc) to share information using a standard called FHIRcast. Each application can share what it is doing and the data it is creating, referred to as Context and Content, respectively. Other applications are notified so they can then intelligently synchronize their behavior or use the new data.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/RAD/IRA/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/RAD/IRA",
-    "ci-build" : "http://build.fhir.org/ig/IHE/RAD.IRA/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.rad.ira#1.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://profiles.ihe.net/RAD/IRA/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "PDSm",
-    "category" : "Clinical Documents",
-    "npm-name" : "ans.fhir.fr.pdsm",
-    "description" : "Partage de Documents de Santé en mobilité (PDSm)",
-    "authority" : "ANS (FR)",
-    "country" : "fr",
-    "language" : "fr",
-    "history" : "https://interop.esante.gouv.fr/ig/fhir/pdsm/history.html",
-    "canonical" : "https://interop.esante.gouv.fr/ig/fhir/pdsm",
-    "ci-build" : "https://build.interop.esante.gouv.fr/ig/fhir/pdsm",
-    "editions" : [{
-      "name" : "Release 17.3.2023 (3.0.0)",
-      "ig-version" : "3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "package" : "ans.fhir.fr.pdsm#3.0.0",
-      "url" : "https://interop.esante.gouv.fr/ig/fhir/pdsm/3.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "U.S. Physical Activity IG",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.physical-activity",
-    "description" : "Defines U.S. interoperability expectations related to physical activity, including primary assessment, supporting measures, plans, goals, referrals and patient-engagement.  Supports interoperability between care managers (e.g. EHRs, community health systems, etc.), service providers (physical activity professionals including exercise physiologists, personal trainers, community fitness centers, etc.), as well as patient-facing applications.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/physical-activity/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/physical-activity",
-    "ci-build" : "http://build.fhir.org/ig/HL7/physical-activity",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.0",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.physical-activity#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/physical-activity/STU1"
-    }]
-  },
-  {
-    "name" : "Protocols for Clinical Registry Extraction and Data Submission (CREDS) IG",
-    "category" : "Clinical Registries",
-    "npm-name" : "hl7.fhir.us.registry-protocols",
-    "description" : "This guide profiles how a registry says what needs to be sent, and how a healthcare provider organization can use that to automate the collection and formatting the data into a submission, conforming to registry or FHIR implementation guide defined profiles and protocols.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/registry-protocols/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/registry-protocols",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-registry-protocols-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.registry-protocols#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/registry-protocols/STU1"
-    }]
-  },
-  {
-    "name" : "Real Time Location Services Implementation Guide",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.uv.rtls",
-    "description" : "This implementation guide defines the use of FHIR resources to exchange real time data about where patients, staff, device, or other assets are located within a hospital or other healthcare facility. This data is typically exchanged between a healthcare system and a Real Time Location System (RTLS) that captures, processes, and stores information about the location of tracking tags.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/rtls/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/rtls",
-    "ci-build" : "http://build.fhir.org/ig/HL7/rtls-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.0 Ballot",
-      "ig-version" : "1.0.0-ballot2",
-      "package" : "hl7.fhir.uv.rtls#1.0.0-ballot2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/rtls/2025Sep"
-    }]
-  },
-  {
-    "name" : "Adverse Event Clinical Research R4 Backport",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.ae-research-backport-ig",
-    "description" : "This IG is for the clinical research setting. It defines the data elements needed to support the workflow for collecting and reporting serious and non-serious adverse events in clinical research to meet the need for regulatory submission requirements.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ae-research-backport-ig/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ae-research-backport-ig",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-ae-research-backport-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.uv.ae-research-backport-ig#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/ae-research-backport-ig/STU1"
-    }]
-  },
-  {
-    "name" : "CCDA: Consolidated CDA Release",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.cda.us.ccda",
-    "description" : "C-CDA 3.0 merges the C-CDA R2.1 and the C-CDA Companion Guides, adds C-CDA enhancement requests, and incorporates new design and guidance for USCDI V4. The guide represents C-CDA templates using HL7 FHIR StructureDefinition. It is built upon the underlying CDA standard’s structures defined as Logical Models. These FHIR Logical models are abstract data structures which have been instantiated into physical CDA templates to be implemented in CDA data exchange. As such, it adheres to the CDA Release 2.0 standard and remains a CDA-based Implementation Guide (IG).",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/cda/stds/ccda/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/cda/us/ccda",
-    "ci-build" : "http://build.fhir.org/ig/HL7/CDA-ccda",
-    "product" : ["fhir", "cda"],
-    "editions" : [{
-      "name" : "CCDA 5.0 Ballot",
-      "ig-version" : "5.0.0-ballot",
-      "package" : "hl7.cda.us.ccda#5.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/cda/us/ccda/2026Jan"
-    }]
-  },
-  {
-    "name" : "Adverse Event Clinical Research",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.ae-research-ig",
-    "description" : "This IG is for the clinical research setting. It defines the data elements needed to support the workflow for collecting and reporting serious and non-serious adverse events in clinical research to meet the need for regulatory submission requirements.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ae-research-ig/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ae-research-ig",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-ae-research-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.uv.ae-research-ig#1.0.1",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/ae-research-ig/STU1"
-    }]
-  },
-  {
-    "name" : "FHIR Core Extensions Registry",
-    "category" : "Extensions",
-    "npm-name" : "hl7.fhir.uv.extensions",
-    "description" : "This package defines the 'core extensions' - the extensions defined globally and available to all implementers",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/extensions/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/extensions",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-extensions",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 5.3",
-      "ig-version" : "5.3.0-ballot-tc1",
-      "package" : "hl7.fhir.uv.extensions#5.3.0-ballot-tc1",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/extensions/5.3.0-ballot-tc1"
-    }]
-  },
-  {
-    "name" : "National Directory of Healthcare Providers and Services (NDH) Implementation Guide",
-    "category" : "Administration",
-    "npm-name" : "hl7.fhir.us.ndh",
-    "description" : "Standard for the population, verification and exchange of Health and Social Care Directory information between a Validated National Directory and local directories (primarily for workflow integration).  This applies to individual demographics, organizational demographics, relationship between individuals and organizations, services provided, and electronic endpoint metadata",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/ndh/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/ndh",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-us-ndh",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.ndh#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ndh/STU1"
-    }]
-  },
-  {
-    "name" : "Privacy Consent on FHIR (PCF)",
-    "category" : "Privacy / Security",
-    "npm-name" : "ihe.iti.pcf",
-    "description" : "The Privacy Consent on FHIR (PCF) Profile provides support for patient privacy consents and access control where a FHIR API is used to access Document Sharing Health Information Exchanges.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/PCF/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/PCF",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.PCF/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.1.0",
-      "package" : "ihe.iti.pcf#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/PCF/1.1.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "HL7 Sweden base profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7se.fhir.base",
-    "description" : "Implementation Guide for Swedish Base Profiles",
-    "authority" : "HL7 Sweden",
-    "country" : "se",
-    "history" : "http://hl7.se/fhir/ig/base/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.se/fhir/ig/base",
-    "ci-build" : "http://build.fhir.org/ig/HL7Sweden/basprofiler-r4",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "hl7se.fhir.base#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.se/fhir/ig/base/1.0.0"
-    },
-    {
-      "name" : "Releases",
-      "ig-version" : "1.1.0",
-      "package" : "hl7se.fhir.base#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.se/fhir/ig/base/1.1.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Da Vinci Value-Based Performance Reporting Implementation Guide",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-vbpr",
-    "description" : "This implementation guide enables value-based performance reports to be specified in a standard format and exchanged using standardized mechanisms between payers and providers to support the shift from fee-for-service to value-based care.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-vbpr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/davinci-vbpr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-vbpr",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1.1",
-      "ig-version" : "1.1.0",
-      "package" : "hl7.fhir.us.davinci-vbpr#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-vbpr/STU1.1.0"
-    }]
-  },
-  {
-    "name" : "International Birth And Child Model Implementation Guide",
-    "category" : "Clinical Observations",
-    "npm-name" : "hl7.fhir.uv.ibcm",
-    "description" : "During a pregnancy clinical systems communicate data about the mother, the unborn fetus(es), the pregnancy, and child(ren). This includes information shared among EHR, ultrasound, radiology, lab and pharmacy systems. This IG explains how you model and communicate data and relate the fetus(es) to the mother using the FHIR resource Patient with extension indicating a distinct fetal record. Options for referencing information such as observation about the fetus as a body site within the maternal record will also be included. Examples and diagrams are provided to illustrate the use cases.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ibcm/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ibcm",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fetal_records",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot2",
-      "package" : "hl7.fhir.uv.ibcm#1.0.0-ballot2",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/ibcm/2024Sep"
-    }]
-  },
-  {
-    "name" : "Canonical Resource Management Infrastructure Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.fhir.uv.crmi",
-    "description" : "The Canonical Resource Management Infrastructure implementation guide defines profiles, operations, capability statements and guidance to facilitate the content management lifecycle for authoring, publishing, distribution, and implementation of FHIR knowledge artifacts such as value sets, profiles, libraries, rules, and measures. The guide is intended to be used by specification and content implementation guide authors as both a dependency for validation of published artifacts, and a guide for construction and publication of content.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/crmi/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/crmi",
-    "ci-build" : "http://build.fhir.org/ig/HL7/crmi-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.uv.crmi#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/crmi/2025Sep"
-    }]
-  },
-  {
-    "name" : "Evidence Based Medicine on FHIR Implementation Guide",
-    "category" : "Evidence Base Medicine",
-    "npm-name" : "hl7.fhir.uv.ebm",
-    "description" : "This implementation guide covers the broad scope of representation of scientific knowledge, including (1) citations to represent identification, location, classification, and attribution for knowledge artifacts; (2) components of research study design including study eligibility criteria (cohort definitions) and endpoint analysis plans; (3) research results including the statistic findings, definition of variables for which those findings apply, and the certainty of these findings; (4) assessments of research results; (5) aggregation and synthesis of research results; (6) judgments regarding evidence syntheses and contextual factors related to recommendations; (7) recommendations; and (8) compositions of combinations of these types of knowledge. The types of interoperability covered include syntactic (Resource StructureDefinitions) and semantic (value sets).",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/ebm/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/ebm",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ebm",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot2",
-      "package" : "hl7.fhir.uv.ebm#1.0.0-ballot2",
-      "fhir-version" : ["6.0.0"],
-      "url" : "http://hl7.org/fhir/uv/ebm/2025May"
-    }]
-  },
-  {
-    "name" : "KLTerm",
-    "category" : "Terminology",
-    "npm-name" : "kl.dk.fhir.term",
-    "description" : "Base Terminology for KL",
-    "authority" : "Kommunernes Landsforening (DK)",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/term/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/term",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-term",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "2.3.0",
-      "package" : "kl.dk.fhir.term#2.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/term/2.3.0"
-    }]
-  },
-  {
-    "name" : "KLCore",
-    "category" : "Frameworks",
-    "npm-name" : "kl.dk.fhir.core",
-    "description" : "Base Profiles for KL",
-    "authority" : "Kommunernes Landsforening (DK)",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/core/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/core",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/KL-dk",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.2.0",
-      "package" : "kl.dk.fhir.core#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/core/1.2.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "KLGateway",
-    "category" : "Clinical Registries",
-    "npm-name" : "kl.dk.fhir.gateway",
-    "description" : "KL Submission Guide of data for reporting of various elements",
-    "authority" : "Kommunernes Landsforening (DK)",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/gateway/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/gateway",
-    "product" : ["fhir"],
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-gateway/branches/main",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.2.0",
-      "package" : "kl.dk.fhir.gateway#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/gateway/1.2.0"
-    }]
-  },
-  {
-    "name" : "Sharing of IPS (sIPS)",
-    "category" : "Clinical Documents",
-    "npm-name" : "ihe.iti.sips",
-    "description" : "Defines how HL7 FHIR IPS is communicated using IHE Document Sharing",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/sIPS/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/sIPS",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.sIPS/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.iti.sips#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/sIPS/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "KLFFBMessaging",
-    "category" : "Frameworks",
-    "npm-name" : "kl.dk.fhir.ffbmessaging",
-    "description" : "Danish municipalities implementation guide for FFB messaging. A standard for exchanging social information from citizen journals between municipalities. The aim is to support citizens continuously, e.g. when they move, or receives interventions outside their home municipality.",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/ffbmessaging/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/ffbmessaging",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-ffb-messaging",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "kl.dk.fhir.ffbmessaging#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/ffbmessaging/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "KLFFinst",
-    "category" : "Frameworks",
-    "npm-name" : "kl.dk.fhir.ffinst",
-    "description" : "Danish municipalities implementation guide for FFInst ",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/ffinst/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/ffinst",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/KL-dk-tools",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "kl.dk.fhir.ffinst#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/ffinst/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "KLFFBReporting",
-    "category" : "Clinical Registries",
-    "npm-name" : "kl.dk.fhir.ffbreporting",
-    "description" : "Danish municipalities implementation guide for FFB reporting. A standard for reporting social information from citizen journals to a gateway. The aim is to use the data in population based studies and management information systems",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/ffbreporting/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/ffbreporting",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-ffb-reporting",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "kl.dk.fhir.ffbreporting#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/ffbreporting/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Animal terapeuta (não humano)",
-    "category" : "Research",
-    "npm-name" : "animal.terapeuta",
-    "description" : "Cadastro de animais terapeutas visando a facilidade de localização deles pelas habilidades.",
-    "authority" : "CGIS (UFG) (BR)",
-    "country" : "br",
-    "history" : "https://fhir.fabrica.inf.ufg.br/ig/history.html",
-    "language" : ["pt"],
-    "canonical" : "https://fhir.fabrica.inf.ufg.br/ig",
-    "ci-build" : "https://fhir.fabrica.inf.ufg.br/ig",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.1.2",
-      "package" : "animal.terapeuta#0.1.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://fhir.fabrica.inf.ufg.br/ig"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Guia de Implementação da SES GO - CORE",
-    "category" : "Medication / Immunization",
-    "npm-name" : "br.go.ses.core",
-    "description" : "Guia de Implementação da SES GO - CORE",
-    "authority" : "Secretaria de Estado da Saúde de Goiás",
-    "country" : "br",
-    "history" : "https://fhir.saude.go.gov.br/r4/core/history.html",
-    "language" : ["pt"],
-    "canonical" : "https://fhir.saude.go.gov.br/r4/core",
-    "ci-build" : "https://fhir.saude.go.gov.br/r4/core",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.0.1",
-      "package" : "br.go.ses.core#0.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://fhir.saude.go.gov.br/r4/core"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Common FHIR profile vendor collaboration",
-    "category" : "EHR Access",
-    "npm-name" : "care.commonprofiles.fhir",
-    "description" : "ImplementationGuide published by a collaborative group of Swedish stakeholders of healthcare IT systems.",
-    "authority" : "CommonProfiles.care (SE)",
-    "country" : "se",
-    "history" : "https://commonprofiles.care/fhir/history.html",
-    "language" : ["en"],
-    "canonical" : "https://commonprofiles.care/fhir",
-    "ci-build" : "https://build.fhir.org/ig/commonprofiles-care/fhir",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.1",
-      "package" : "care.commonprofiles.fhir#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://commonprofiles.care/fhir/1.0.1"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "KLGatewayRehab",
-    "category" : "Clinical Registries",
-    "npm-name" : "kl.dk.fhir.rehab",
-    "description" : "This implementation guide describes the delivery of §140 rehabilitation data to KL Gateway.",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/rehab/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/rehab",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-gateway-rehab",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "2.2.0",
-      "package" : "kl.dk.fhir.rehab#2.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/rehab/2.2.0"
-    }]
-  },
-  {
-    "name" : "KLGatewayPrevention",
-    "category" : "Clinical Registries",
-    "npm-name" : "kl.dk.fhir.prevention",
-    "description" : "This implementation guide describes the delivery of §119 prevention/health promotion data to KL Gateway.",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/prevention/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/prevention",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-gateway-prevention",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "2.0.0",
-      "package" : "kl.dk.fhir.prevention#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/prevention/2.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "KLChildren",
-    "category" : "Clinical Registries",
-    "npm-name" : "kl.dk.fhir.children",
-    "description" : "This implementation guide describes the delivery of children health data to KL Gateway.",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://fhir.kl.dk/children/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.kl.dk/children",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/kl-children",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "2.1.0",
-      "package" : "kl.dk.fhir.children#2.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.kl.dk/children/2.1.0"
-    }]
-  },
-  {
-    "name" : "KR Core Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.kr.core",
-    "description" : "Base Korean national implementation guide",
-    "authority" : "HL7 Korea",
-    "product" : ["fhir"],
-    "country" : "kr",
-    "language" : ["ko"],
-    "history" : "http://www.hl7korea.or.kr/fhir/krcore/history.html",
-    "ci-build" : "https://build.fhir.org/ig/hl7korea/krcore",
-    "canonical" : "http://www.hl7korea.or.kr/fhir/krcore",
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.2",
-      "package" : "hl7.fhir.kr.core#1.0.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://www.hl7korea.or.kr/fhir/krcore/STU1.0.2"
-    },
-    {
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.kr.core#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://www.hl7korea.or.kr/fhir/krcore/STU2"
-    }]
-  },
-  {
-    "name" : "Japanese Core Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.jp.core",
-    "description" : "A core set of FHIR resources profiled for the Japanese context",
-    "authority" : "HL7 Japan (JAMI)",
-    "product" : ["fhir"],
-    "country" : "jp",
-    "language" : ["ja"],
-    "history" : "https://jpfhir.jp/fhir/core/history.html",
-    "canonical" : "http://jpfhir.jp/fhir/core",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.2.0",
-      "package" : "jpfhir.jp.core#1.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://jpfhir.jp/fhir/core/1.2.0"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.1.2",
-      "package" : "jpfhir.jp.core#1.1.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://jpfhir.jp/fhir/core/1.1.2"
-    }]
-  },
-  {
-    "name" : "Health Checkup Report Implementation Guide",
-    "category" : "Clinical Documents",
-    "npm-name" : "jp-eCheckupReport.r4",
-    "description" : "This guide defines the FHIR data representation and associated profiles for Health Checkup Report",
-    "authority" : "HL7 Japan (JAMI)",
-    "product" : ["fhir"],
-    "country" : "jp",
-    "language" : ["ja"],
-    "canonical" : "http://jpfhir.jp/fhir/eCheckupReport",
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.6.0",
-      "package" : "eCheckupReport#1.6.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://jpfhir.jp/fhir/eCheckup/igv1"
-    }]
-  },
-  {
-    "name" : "Clinical Information Sharing Implementation Guide",
-    "category" : "Clinical Documents",
-    "npm-name" : "jp-eCSCLINS.r4",
-    "description" : "This guide defines the FHIR data representation and associated profiles for the two documents and the five pieces of information defined by the Ministry of Health, Labor and Welfare",
-    "authority" : "HL7 Japan (JAMI)",
-    "product" : ["fhir"],
-    "country" : "jp",
-    "language" : ["ja"],
-    "history" : "https://jpfhir.jp/fhir/clins/history.html",
-    "canonical" : "http://jpfhir.jp/fhir/clins",
-    "editions" : [{
-      "name" : "jp-eCSCLINS.r4",
-      "ig-version" : "1.11.0",
-      "package" : "clinical-information-sharing#1.11.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://jpfhir.jp/fhir/clins/igv1"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Laboratory Report",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.eu.laboratory",
-    "description" : "This guide defines a set of common rules to be applied to HL7 FHIR to represent a Laboratory Report in the European Context, coherently with the European eHN Guidelines",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/laboratory/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/laboratory",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/laboratory",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.1",
-      "ig-version" : "0.1.1",
-      "package" : "hl7.fhir.eu.laboratory#0.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/laboratory/0.1.1"
-    }]
-  },
-  {
-    "name" : "HL7 FHIR Implementation Guide: Public Health IG Release 1 - BE Realm | STU1",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.public-health",
-    "description" : "HL7 FHIR Implementation Guide: Public Health IG Release 1 - BE Realm | STU1",
-    "authority" : "eHealth Platform Belgium",
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/public-health/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/public-health",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/public-health",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.public-health#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/public-health/1.0.0"
-    },
-    {
-      "name" : "Trial Use",
-      "ig-version" : "1.0.2",
-      "package" : "hl7.fhir.be.public-health#1.0.2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/public-health/1.0.2"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "eHealth FHIR Infrastructure and Security Profiles for Belgium",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.infsec",
-    "description" : "eHealth FHIR Infrastructure and Security Profiles for Belgium",
-    "authority" : "eHealth Platform Belgium",
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/infsec/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/infsec",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/infsec",
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.infsec#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/infsec/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Finnish Implementation Guide for SMART App Launch",
-    "npm-name" : "hl7.fhir.fi.smart",
-    "category" : "National Base",
-    "description" : "Guidelines for using the SMART App Launch mechanism in Finland, published and maintained by HL7 Finland.",
-    "authority" : "HL7",
-    "country" : "fi",
-    "history" : "https://hl7.fi/fhir/finnish-smart/history.html",
-    "language" : ["en"],
-    "canonical" : "https://hl7.fi/fhir/finnish-smart",
-    "ci-build" : "https://fhir.fi/finnish-smart",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.fi.smart#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.fi/fhir/finnish-smart/2.0.0"
-    }]
-  },
-  {
-    "name" : "Finnish Base Profiles",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.fi.base",
-    "description" : "A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland",
-    "authority" : "HL7",
-    "country" : "fi",
-    "history" : "https://hl7.fi/fhir/finnish-base-profiles/history.html",
-    "language" : ["en"],
-    "canonical" : "https://hl7.fi/fhir/finnish-base-profiles",
-    "ci-build" : "https://fhir.fi/finnish-base-profiles",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.fi.base#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.fi/fhir/finnish-base-profiles/2.0.0"
-    }]
-  },
-  {
-    "name" : "Finnish Scheduling",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.fi.scheduling",
-    "description" : "Finnish HL7 FHIR implementation guide for scheduling, published and maintained by HL7 Finland",
-    "authority" : "HL7",
-    "country" : "fi",
-    "history" : "https://hl7.fi/fhir/finnish-scheduling/history.html",
-    "language" : ["en"],
-    "canonical" : "https://hl7.fi/fhir/finnish-scheduling",
-    "ci-build" : "https://fhir.fi/finnish-scheduling",
-    "editions" : [{
-      "name" : "STU 2 Ballot",
-      "ig-version" : "2.0.0-rc3",
-      "package" : "hl7.fhir.fi.scheduling#2.0.0-rc3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.fi/fhir/finnish-scheduling/2.0.0-rc3"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Document Subscription for Mobile (DSUBm)",
-    "category" : "Clinical Documents",
-    "npm-name" : "ihe.iti.dsubm",
-    "description" : "The Document Subscription for Mobile (DSUBm) profile provides a FHIR based subscription and notification mechanisms for Document Sharing. Enabling a subscription and notification when a document publication event matches the criteria expressed in the subscription.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/DSUBm/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/DSUBm",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.DSUBm/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.iti.dsubm#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/DSUBm/1.0.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "HRSA Uniform Data System (UDS) Patient Level Submission (PLS) (UDS+ or uds-plus) FHIR IG",
-    "category" : "Surveillience / Reporting",
-    "npm-name" : "fhir.hrsa.uds-plus",
-    "description" : "UDS+ is part of HRSA`s modernization initiatives and requires health centers to report data annually as part of the funding grants. UDS is a standard data set that provides consistent information about Federally Qualified Health Centers. It is the source of non duplicated data for the entire scope of services included in the grant or designation for the calendar year. HRSA uses UDS data to assess the impact and performance of the Health Center Program, and to promote data-driven quality improvement",
-    "authority" : "US Government",
-    "country" : "us",
-    "history" : "http://fhir.org/guides/hrsa/uds-plus/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.org/guides/hrsa/uds-plus",
-    "ci-build" : "http://build.fhir.org/ig/drajer-health/uds-plus",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "fhir.hrsa.uds-plus#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.org/guides/hrsa/uds-plus/STU2"
-    }]
-  },
-  {
-    "name" : "Pharmaceutical Quality (Industry)",
-    "category" : "Pharmaceutical",
-    "npm-name" : "hl7.fhir.uv.pharm-quality",
-    "description" : "The FHIR resource profiles specified in this implementation guide represent data in the ICH Quality Guidelines (https://www.ich.org/page/quality-guidelines). This implementation guide defines universal realm structured data elements to support structured authoring (e.g., master data; advanced analysis) for the creation and exchange of Quality information internationally.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/pharm-quality/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/pharm-quality",
-    "ci-build" : "http://build.fhir.org/ig/HL7/uv-dx-pq",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.pharm-quality#1.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/pharm-quality/STU1"
-    }]
-  },
-  {
-    "name" : "Using CQL with FHIR Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.fhir.uv.cql",
-    "description" : "The Using CQL with FHIR implementation guide defines profiles, operations and guidance for the use of CQL with FHIR, both as a mechanism for querying, as well as inline and integrated usage as part of knowledge artifacts.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cql/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cql",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cql-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.uv.cql#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cql/STU2"
-    }]
-  },
-  {
-    "name" : "Respiratory Virus Hospitalization Surveillance Network (RESP-NET) Content Implementation Guide",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.resp-net",
-    "description" : "The Respiratory Virus Hospitalization Surveillance Network (RESP-NET) comprises three platforms that conduct population-based surveillance for laboratory-confirmed hospitalizations associated with COVID-19, Influenza, and Respiratory Syncytial Virus (RSV) among children and adults.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/resp-net/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/resp-net",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-resp-net-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.resp-net#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/resp-net/2025Sep"
-    }]
-  },
-  {
-    "name" : "US Prescription Drug Monitoring Program (PDMP)",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.pdmp",
-    "description" : "Guidance on the use of FHIR resources and search operations to allow requestors (prescribers, pharmacists, others) to obtain a patient's medication records held in one or more Prescription Drug Monitoring Programs (PDMPs).  Also describes how the information supplied by the PDMPs is contained in the other information exchanges in the larger PDMP environment.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pdmp/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pdmp",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-pdmp",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.pdmp#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pdmp/STU1"
-    }]
-  },
-  {
-    "name" : "US Medication REMS",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "hl7.fhir.us.medication-rems",
-    "description" : "A Risk Evaluation and Mitigation Strategies (REMS) is a drug safety program that the U.S. FDA requires for certain medications with serious safety concerns. Complying with REMS can introduce manual work for the provider and potential delays in getting the medication to the patient. This IG provides guidance on using FHIR to automate notifications and information exchange between the provider and the REMS Administrator--to reduce burden on the provider and prevent delays in patient care.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/medication-rems/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/medication-rems",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-medication-rems-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.medication-rems#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/medication-rems/STU2"
-    }]
-  },
-  {
-    "name" : "CardX Hypertension Management IG",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.cardx-htn-mng",
-    "description" : "This implementation guide is intended to increase the quality of blood pressure data observed by the patient taken in a non-clinical setting or at home.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cardx-htn-mng/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cardx-htn-mng",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cardx-htn-mng",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.cardx-htn-mng#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cardx-htn-mng/STU1"
-    }]
-  },
-  {
-    "name" : "Pharmaceutical Quality - Chemistry, Manufacturing and Controls (PQ-CMC) Submissions to FDA",
-    "category" : "Pharmaceutical",
-    "npm-name" : "hl7.fhir.us.pq-cmc-fda",
-    "description" : "The FDA PQ-CMC FHIR IG is for submission of structured and standardized information regarding drug product quality, chemistry, manufacturing and processes controls.  This data is intended for submission to the US FDA by biopharmaceutical companies for the purpose of drug application review.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pq-cmc-fda/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pq-cmc-fda",
-    "ci-build" : "http://build.fhir.org/ig/HL7/FHIR-us-pq-cmc-fda",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.fhir.us.pq-cmc-fda#2.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/us/pq-cmc-fda/STU2"
-    }]
-  },
-  {
-    "name" : "HL7 Tools Extension IG",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.fhir.uv.tools",
-    "description" : "Definitions of the code systems and extensions used by the FHIR tools (validators, code generators, IG publication, etc)",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/tools/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/tools",
-    "ci-build" : "http://build.fhir.org/ig/FHIR/fhir-tools-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release Informative",
-      "ig-version" : "1.1.2",
-      "package" : "hl7.fhir.uv.tools#1.1.2",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/tools/1.1.2"
-    }]
-  },
-  {
-    "name" : "FHIR Implementation Guide for ABDM",
-    "category" : "National Base",
-    "npm-name" : "ndhm.in",
-    "description" : "FHIR Implementation Guide for Ayushman Bharat Digital Mission",
-    "authority" : "NRCeS",
-    "country" : "in",
-    "history" : "https://nrces.in/ndhm/fhir/r4/history.html",
-    "language" : ["en"],
-    "canonical" : "https://nrces.in/ndhm/fhir/r4",
-    "ci-build" : "https://nrces.in/ndhm/fhir/r4",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "6.5.0",
-      "package" : "ndhm.in#6.5.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://nrces.in/ndhm/fhir/r4/6.5.0"
-    }]
-  },
-  {
-    "name" : "IHE FHIR Profile: Occupational Data for Health (ODH) - International",
-    "category" : "Clinical Observations",
-    "npm-name" : "ihe.pcc.odh",
-    "description" : "This IG covers the specific data that covers past or present jobs, usual work, employment status, retirement date and combat zone period for the subject. It also includes the past or present jobs and usual work of other household members. This IG is International scope",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/PCC/ODH/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/PCC/ODH",
-    "ci-build" : "http://build.fhir.org/ig/IHE/PCC.ODH/branches/master/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.pcc.odh#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/PCC/ODH/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Extensions",
-    "category" : "Extensions",
-    "npm-name" : "hl7.fhir.eu.extensions",
-    "description" : "This guide lists the extensions specified for the European REALM.",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/extensions/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/extensions",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/extensions",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.3.0",
-      "package" : "hl7.fhir.eu.extensions#1.3.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.eu/fhir/extensions/1.3.0"
-    }]
-  },
-  {
-    "name" : "HL7 FHIR Implementation Guide Laboratory Report",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.it.lab-report",
-    "description" : "This guide defines a set of common rules to be applied to HL7 FHIR to represent a Laboratory Report in the Italian Context, coherently with the European FHIR Implementation Guide",
-    "authority" : "HL7 Italia",
-    "country" : "it",
-    "history" : "http://hl7.it/fhir/lab-report/history.html",
-    "language" : ["it"],
-    "canonical" : "http://hl7.it/fhir/lab-report",
-    "ci-build" : "http://build.fhir.org/ig/hl7-it/lab-report",
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.it.lab-report#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.it/fhir/lab-report/0.2.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "IG Tooling by GKL",
-    "category" : "Research",
-    "npm-name" : "hl7.at.fhir.gkl.ig-tooling",
-    "description" : "This IG is built in order to describe the IG tooling.",
-    "country" : "at",
-    "authority" : "Unspecified",
-    "history" : "https://gabriel0316.github.io/ig-tooling-pages/ig/ig-tooling/history.html",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/gabriel0316/ig-tooling",
-    "canonical" : "https://gabriel0316.github.io/ig-tooling-pages/ig/ig-tooling-test",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "DSTU 1",
-      "ig-version" : "0.5.3",
-      "package" : "hl7.at.fhir.gkl.ig-tooling#0.5.3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://gabriel0316.github.io/ig-tooling-pages/ig/ig-tooling-test/0.5.3"
-    }]
-  },
-  {
-    "name" : "FHIR Clinical Documents",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.fhir.uv.fhir-clinical-document",
-    "description" : "The FHIR Clinical Document Implementation Guide is a canonical representation of a clinical document in FHIR. The IG serves as a common universal starting point for those creating their own FHIR clinical document specifications, and supports those CDA users wishing to migrate to a FHIR-based representation of clinical documents.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/fhir-clinical-document/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/fhir-clinical-document",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-clinical-document/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.fhir-clinical-document#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/fhir-clinical-document/STU1"
-    }]
-  },
-  {
-    "name" : "SMART Health Cards and Links FHIR IG",
-    "category" : "Communications",
-    "npm-name" : "hl7.fhir.uv.smart-health-cards-and-links",
-    "description" : "This Implementation Guide defines secure, standards-based mechanisms for individuals to store, share, and manage their health data. It encompasses SMART Health Cards (SHC) for verifiable clinical records and SMART Health Links (SHL) for flexible sharing of FHIR data, including patient-supplied information, dynamic records, and authorization delegation.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/smart-health-cards-and-links/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/smart-health-cards-and-links",
-    "ci-build" : "http://build.fhir.org/ig/HL7/smart-health-cards-and-links",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.smart-health-cards-and-links#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/smart-health-cards-and-links/STU1"
-    }]
-  },
-  {
-    "name" : "RIVO-Noord Zorgviewer",
-    "npm-name" : "hl7.fhir.nl.zorgviewer",
-    "category" : "EHR Access",
-    "description" : "De zorgviewer biedt zorgverleners een 360° beeld van de patiënt of cliënt. Opgebouwd uit alle beschikbare zorginformatie, waarvoor de patiënt of cliënt toestemming heeft gegeven.",
-    "authority" : "RIVO-Noord (NL)",
-    "product" : ["fhir"],
-    "country" : "nl",
-    "language" : ["nl"],
-    "history" : "https://implementatiegids.zorgviewer.nl/changes.html",
-    "canonical" : "http://fhir.hl7.nl/zorgviewer",
-    "ci-build" : "https://build.fhir.org/ig/RIVO-Noord/zorgviewer-ig",
-    "editions" : [{
-      "name" : "Sprint 70",
-      "ig-version" : "1.21.0",
-      "package" : "hl7.fhir.nl.zorgviewer#1.21.0",
-      "fhir-version" : ["3.0.2"],
-      "url" : "https://implementatiegids.zorgviewer.nl"
-    }]
-  },
-  {
-    "name" : "Mobile Antepartum Summary",
-    "category" : "Clinical Observations",
-    "npm-name" : "ihe.pcc.maps",
-    "description" : "Antepartum Summary is a content profile that defines the structure for the aggregation of significant events, diagnoses, and plans of care derived from the visits over the course of an antepartum episode.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/PCC/mAPS/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/PCC/mAPS",
-    "ci-build" : "http://build.fhir.org/ig/IHE/PCC.mAPS/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication Ballot",
-      "ig-version" : "1.0.0-comment",
-      "package" : "ihe.pcc.maps#1.0.0-comment",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/PCC/mAPS/1.0.0-comment"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "Mobile Antepartum Summary US Realm",
-    "category" : "Clinical Observations",
-    "npm-name" : "ihe.pcc.maps.us",
-    "description" : "Antepartum Summary is a content profile that defines the structure for the aggregation of significant events, diagnoses, and plans of care derived from the visits over the course of an antepartum episode.",
-    "authority" : "IHE",
-    "country" : "us",
-    "history" : "https://profiles.ihe.net/us/PCC/mAPS/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/us/PCC/mAPS",
-    "ci-build" : "http://build.fhir.org/ig/IHE/PCC.mAPS.us/branches/master/index.html",
-    "editions" : [{
-      "name" : "Publication Ballot",
-      "ig-version" : "1.0.0-comment",
-      "package" : "ihe.pcc.maps.us#1.0.0-comment",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/us/PCC/mAPS/1.0.0-comment"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "IHE ITI Finance and Insurance Services",
-    "category" : "Financial",
-    "npm-name" : "ihe.iti.fais",
-    "description" : "The Finance and Insurance Service (FAIS) stores, categorizes, and facilitates the administration of centralized claims and finance data for patient care. The service receives claims/financial data from Point of Service applications (including financing applications acting as a point of service interface outside of other PoS systems) and curates the management of them.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/FAIS/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/FAIS",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.Finance ",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.iti.fais#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/FAIS/1.0.0"
-    }]
-  },
-  {
-    "name" : "IHE ITI Scheduling",
-    "category" : "Administration",
-    "npm-name" : "ihe.iti.scheduling",
-    "description" : "The IHE FHIR Scheduling Profile is a specification providing FHIR APIs and guidance for access to and booking of appointments for patients by both patient and practitioner end users. This specification is based on FHIR Version 4 and specifically the Schedule, Slot, and Appointment resources, and on the previous work of the [Argonaut Project](https://fhir.org/guides/argonaut/scheduling/release1/)",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/ITI/Scheduling/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/ITI/Scheduling",
-    "ci-build" : "http://build.fhir.org/ig/IHE/ITI.Scheduling",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.iti.scheduling#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/ITI/Scheduling/1.0.0"
-    }]
-  },
-  {
-    "name" : "US Standardized Medication Profile (SMP)",
-    "category" : "Medications ",
-    "npm-name" : "hl7.fhir.us.smp",
-    "description" : "Standardized Medication Profile",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/smp/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/smp",
-    "ci-build" : "http://build.fhir.org/ig/HL7/smp",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.smp#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/smp/STU1"
-    }]
-  },
-  {
-    "name" : "DICOM® SR to FHIR Resource Mapping IG",
-    "category" : "Imaging",
-    "npm-name" : "hl7.fhir.uv.dicom-sr",
-    "description" : "Provides guidance for extracting key content from DICOM Structured Report (SR) objects into FHIR Observations  to make use of the results with  the larger hospital enterprise.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/dicom-sr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/dicom-sr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/dicom-sr",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.dicom-sr#1.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/dicom-sr/2024Sep"
-    }]
-  },
-  {
-    "name" : "National Healthcare Safety Network (NHSN) Digital Quality Measure (dQM) Reporting Implementation Guide",
-    "category" : "Medication / Immunization",
-    "npm-name" : "hl7.fhir.us.nhsn-dqm",
-    "description" : "This implementation guide creates a framework for reporting to the National Healthcare Safety Network (NHSN) using digital quality measures (dQMs). NHSN will create FHIR Measure resources that comply with this framework and receive the resulting MeasureReport and related resources. The Measure resources will be processed by a measure evaluation engine, which can either pull data from an EHR FHIR API for evaluation, or be implemented inside an EHR directly.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/nhsn-dqm/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/nhsn-dqm",
-    "ci-build" : "http://build.fhir.org/ig/HL7/nhsn-dqm",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.nhsn-dqm#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/nhsn-dqm/STU1"
-    }]
-  },
-  {
-    "name" : "FHIR Application Feature Framework Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.fhir.uv.application-feature",
-    "description" : "This IG defines profiles and extensions to implement features that were formerly considered for what was known as CapabilityStatement2. This includes a terminology-based approach to managing new assertions around system capabilities, which will allow for feature negotiation.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/application-feature/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/application-feature",
-    "ci-build" : "http://build.fhir.org/ig/HL7/capstmt",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.application-feature#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/application-feature/2024Sep"
-    }]
-  },
-  {
-    "name" : "Terminology Change Set Exchange",
-    "category" : "Terminology",
-    "npm-name" : "hl7.fhir.uv.termchangeset",
-    "description" : "This IG provides profiles and implementation guidance for exchanging terminology change sets that include full semantic detail from the source terminology utilizing the CodeSystem resource.  It also addresses exchanging terminology change sets containing provisional concepts not yet incorporated in source terminologies. Analysis of semantic detail to include in a change set is informed by the Tinkar Standardized Terminology Knowledgebase (https://www.hl7.org/implement/standards/product_brief.cfm?product_id=573) Reference Model, and mappings from that model are included on CodeSystem profiles.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/termchangeset/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/termchangeset",
-    "ci-build" : "http://build.fhir.org/ig/HL7/termchangeset-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.termchangeset#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/termchangeset/2024Sep"
-    }]
-  },
-  {
-    "name" : "HL7 Laboratory Report",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.lab-report",
-    "description" : "Universal implementation guide for laboratory reporting using FHIR (based on FHIR document or DiagnosticReport)",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/lab-report/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/lab-report",
-    "ci-build" : "http://build.fhir.org/ig/HL7/uv-lab-rep-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.lab-report#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/lab-report/2024Sep"
-    }]
-  },
-  {
-    "name" : "FUT Infrastructure",
-    "category" : "Frameworks",
-    "npm-name" : "dk.ehealth.sundhed.fhir.ig.core",
-    "description" : "The Danish eHealth Infrastructure Implementation Guide defines a set of FHIR profiles with extensions and bindings needed to create interoperable, quality-focused applications.",
-    "authority" : "Den telemedicinske infrastruktur",
-    "country" : "dk",
-    "history" : "http://ehealth.sundhed.dk/fhir/history.html",
-    "language" : ["en"],
-    "canonical" : "http://ehealth.sundhed.dk/fhir",
-    "ci-build" : "http://build.fhir.org/ig/fut-infrastructure/implementation-guide",
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "3.4.1",
-      "package" : "dk.ehealth.sundhed.fhir.ig.core#3.4.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://ehealth.sundhed.dk/fhir/3.4.1"
-    },
-    {
-      "name" : "Releases",
-      "ig-version" : "3.4.0",
-      "package" : "dk.ehealth.sundhed.fhir.ig.core#3.4.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://ehealth.sundhed.dk/fhir/3.4.0"
-    },
-    {
-      "name" : "Releases",
-      "ig-version" : "3.3.0",
-      "package" : "dk.ehealth.sundhed.fhir.ig.core#3.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://ehealth.sundhed.dk/fhir/3.3.0"
-    },
-    {
-      "name" : "Releases",
-      "ig-version" : "3.2.0",
-      "package" : "dk.ehealth.sundhed.fhir.ig.core#3.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://ehealth.sundhed.dk/fhir/3.2.0"
-    },
-    {
-      "name" : "Releases",
-      "ig-version" : "3.1.0",
-      "package" : "dk.ehealth.sundhed.fhir.ig.core#3.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://ehealth.sundhed.dk/fhir/3.1.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "SMART Base",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.base",
-    "description" : "Base SMART Guidelines implementation guide to be used as the base dependency for all SMART Guidelines IGs",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/base/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/base",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-base",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases Draft",
-      "ig-version" : "0.2.0",
-      "package" : "smart.who.int.base#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/base/0.2.0"
-    }]
-  },
-  {
-    "name" : "SMART TS",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.ts",
-    "description" : "SMART Guidelines Terminology artifacts and resources to be used as the across all SMART Guidelines IGs",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/ts/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/ts",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-ts",
-    "editions" : [{
-      "name" : "Releases Draft",
-      "ig-version" : "0.1.0",
-      "package" : "smart.who.int.ts#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/ts/0.1.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "SMART ICVP",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.icvp",
-    "description" : "SMART Guidelines for International Certificate for Vaccination or Prophylaxis",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/icvp/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/icvp",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-icvp",
-    "editions" : [{
-      "name" : "Releases Draft",
-      "ig-version" : "0.3.0",
-      "package" : "smart.who.int.icvp#0.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/icvp/0.3.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "SMART TRUST PHW",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.trust-phw",
-    "description" : "Specifications for usage of Personal Health Wallet (PHW) with WHO GDHCN Trust Network",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/trust-phw/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/trust-phw",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-trust-phw",
-    "editions" : [{
-      "name" : "Releases Draft",
-      "ig-version" : "0.1.0",
-      "package" : "smart.who.int.trust-phw#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/trust-phw/0.1.0"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "WHO Digital Documentation of COVID-19 Certificates (DDCC)",
-    "category" : "SMART (WHO)",
-    "npm-name" : "who.ddcc",
-    "description" : "This WHO Digital Documentation of COVID-19 Certificates (DDCC) Implementation Guide details how to use Health Level 7 (HL7) Fast Healthcare Interoperability Resources (FHIR) for consistent digital representation of COVID-19 certificates and interoperability",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/ddcc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/ddcc",
-    "ci-build" : "http://worldhealthorganization.github.io/ddcc",
-    "editions" : [{
-      "name" : "releases Draft",
-      "ig-version" : "1.0.1",
-      "package" : "who.ddcc#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/ddcc/1.0.1"
-    }],
-    "product" : ["fhir"]
-  },
-  {
-    "name" : "SMART Trust",
-    "category" : "Privacy / Security",
-    "npm-name" : "smart.who.int.trust",
-    "description" : "SMART Trust Implementation Guide",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/trust/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/trust",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-trust",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.4.0",
-      "package" : "smart.who.int.trust#1.4.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://smart.who.int/trust/1.4.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK IMMZ",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-immz",
-    "description" : "SMART Guidelines Digital Adaptation Kit (DAK) for Immunizations",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-immz/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-immz",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-dak-immz",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.1.0",
-      "package" : "smart.who.int.dak-immz#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-immz/v1.1.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK CCC",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-ccc",
-    "description" : "SMART Guidelines Digital Adaptation Kit (DAK) for Clinical Care in Crises (CCC)",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-ccc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-ccc",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-dak-ccc",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "smart.who.int.dak-ccc#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-ccc/v1.0.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK TB",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-tb",
-    "description" : "SMART Guidelines Digital Adaptation Kit (DAK) for tuberculosis (TB)",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-tb/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-tb",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-dak-tb",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.1",
-      "package" : "smart.who.int.dak-tb#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-tb/v1.0.1"
-    }]
-  },
-  {
-    "name" : "SMART Verifiable IPS for Pilgrimage",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.ips-pilgrimage",
-    "description" : "SMART Verifiable IPS for Pilgrimage",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/ips-pilgrimage/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/ips-pilgrimage",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-ips-pilgrimage",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "2.0.3",
-      "package" : "smart.who.int.ips-pilgrimage#2.0.3",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/ips-pilgrimage/2.0.3"
-    }]
-  },
-  {
-    "name" : "SMART Guidelines Starter Kit",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.ig-starter-kit",
-    "description" : "SMART Guidelines Starter Kit",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/ig-starter-kit/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/ig-starter-kit",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-ig-starter-kit",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "2.0.0",
-      "package" : "smart.who.int.ig-starter-kit#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/ig-starter-kit/v2.0.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK BDS",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-bds",
-    "description" : "SMART Digital Adaptation Kit (DAK) for birth defects surveillance (BDS)",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-bds/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-bds",
-    "ci-build" : "http://worldhealthorganization.github.io/dak-bds",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "smart.who.int.dak-bds#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-bds/v1.0.0"
-    }]
-  },
-  {
-    "name" : "SMART PCMT",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.pcmt",
-    "description" : "SMART Product Catalog",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/pcmt/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/pcmt",
-    "ci-build" : "http://worldhealthorganization.github.io/pcmt",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.1.0",
-      "package" : "smart.who.int.pcmt#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/pcmt/v0.1.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK SMBP",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-smbp",
-    "description" : "SMART Digital Adaptation Kit (DAK) for self-monitoring of blood pressure in pregnancy (SMBP)",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-smbp/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-smbp",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-dak-smbp",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "smart.who.int.dak-smbp#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-smbp/v1.0.0"
-    }]
-  },
-  {
-    "name" : "Reference Architecture",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.ra",
-    "description" : "The Reference Architecture Implementation Guide to be used as a starting point for building infrastructure with the SMART Guidelines approach",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/ra/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/ra",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-ra",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.1.0",
-      "package" : "smart.who.int.ra#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/ra/v0.1.0"
-    }]
-  },
-  {
-    "name" : "SMART Product Dataset for Prequalified Vaccines",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.pcmt-vaxprequal",
-    "description" : "Data exchange specifications for Product Catalog supporting the SMART Guidelines",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/pcmt-vaxprequal/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/pcmt-vaxprequal",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-pcmt-vaxprequal",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.2.0",
-      "package" : "smart.who.int.pcmt-vaxprequal#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/pcmt-vaxprequal/v0.2.0"
-    }]
-  },
-  {
-    "name" : "WHO SMART Guidelines - ANC",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.anc",
-    "description" : "SMART Guidelines for Antenatal Care (ANC)",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/anc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/anc",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-anc",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.3.0",
-      "package" : "smart.who.int.anc#0.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/anc/v0.3.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK PNC",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-pnc",
-    "description" : "SMART Digital Adaptation Kit (DAK) for Postnatal Care",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-pnc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-pnc",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-dak-pnc",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "1.0.0",
-      "package" : "smart.who.int.dak-pnc#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-pnc/v1.0.0"
-    }]
-  },
-  {
-    "name" : "SMART DAK SRV",
-    "category" : "SMART (WHO)",
-    "npm-name" : "smart.who.int.dak-srv",
-    "description" : "SMART Digital Adaptation Kit (DAK) for Surveillance",
-    "authority" : "World Health Organization",
-    "country" : "uv",
-    "history" : "http://smart.who.int/dak-srv/history.html",
-    "language" : ["en"],
-    "canonical" : "http://smart.who.int/dak-srv",
-    "ci-build" : "http://worldhealthorganization.github.io/smart-dak-srv",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.9.9",
-      "package" : "smart.who.int.dak-srv#0.9.9",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://smart.who.int/dak-srv/v0.9.9"
-    }]
-  },
-  {
-    "name" : "DaVinci Postable Remittance FHIR Implementation Guide",
-    "category" : "Financial",
-    "npm-name" : "hl7.fhir.us.davinci-pr",
-    "description" : "This IG provides a FHIR API to search for and retrieve a copy of a previously issued postable remittance.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/davinci-pr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/davinci-pr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/davinci-pr",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.davinci-pr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/davinci-pr/STU1"
-    }]
-  },
-  {
-    "name" : "Quality Measure Implementation Guide",
-    "category" : "Quality / CDS",
-    "npm-name" : "hl7.fhir.uv.cqm",
-    "description" : "The Quality Measure Implementation Guide (QM IG) describes an approach to representing Quality Measures (QMs) using the FHIR Clinical Reasoning Module and Clinical Quality Language (CQL). This Implementation Guide can be used for multiple use cases across many domains.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cqm/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cqm",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-cqm",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.cqm#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cqm/STU1"
-    }]
-  },
-  {
-    "name" : "How to Publish a FHIR Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "ca.argentixinfo.howtopub",
-    "description" : "An instruction guide showing how to use the HL7 IG Publisher's -go-publish feature to publish an implementation guide to a website.",
-    "authority" : "Argentix Informatics, Inc.",
-    "country" : "ca",
-    "history" : "http://argentixinfo.com/ig/howtopub/history.html",
-    "language" : ["en"],
-    "canonical" : "http://argentixinfo.com/ig/howtopub",
-    "ci-build" : "http://build.fhir.org/ig/ElliotSilver/how-to-publish",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.1.0",
-      "package" : "ca.argentixinfo.howtopub#1.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://argentixinfo.com/ig/howtopub/1.1.0"
-    }]
-  },
-  {
-    "name" : "Standard Personal Health Record",
-    "category" : "Personal Healthcare",
-    "npm-name" : "hl7.fhir.uv.phr",
-    "description" : "A specifcation for a standard personal health record file format, for collecting and assembling longitudinal records from multiple EHR vendors.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/phr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/phr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/personal-health-record-format-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot2",
-      "package" : "hl7.fhir.uv.phr#1.0.0-ballot2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/phr/2025May"
-    }]
-  },
-  {
-    "name" : "FHIRPath Specification",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.fhirpath",
-    "description" : "FHIRPath specification",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhirpath/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhirpath",
-    "ci-build" : "http://build.fhir.org/ig/HL7/FHIRPath",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "R2 Ballot",
-      "ig-version" : "3.0.0-ballot",
-      "package" : "hl7.fhirpath#3.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhirpath/2025Jan"
-    }]
-  },
-  {
-    "name" : "CH VACD (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-vacd",
-    "description" : "The CH VACD implementation guide describes the FHIR representation of the defined documents for the exchange of immuniuzation",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-vacd/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-vacd",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-vacd",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 5",
-      "ig-version" : "5.0.0",
-      "package" : "ch.fhir.ig.ch-vacd#5.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-vacd/5.0.0"
-    }]
-  },
-  {
-    "name" : "CH-AllergyIntolerance (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-allergyintolerance",
-    "description" : "Swiss Implementation Guide for Allergy & Intolerance based on the recommendations of the interprofessional working group EPR (IPAG).",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-allergyintolerance/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-allergyintolerance",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-allergyintolerance",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 3",
-      "ig-version" : "3.0.0",
-      "package" : "ch.fhir.ig.ch-allergyintolerance#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-allergyintolerance/3.0.0"
-    }]
-  },
-  {
-    "name" : "CH LAB-Order (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-lab-order",
-    "description" : "Swiss Implementation Guide for the exchange of order data in the laboratory sector.",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-lab-order/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-lab-order",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-lab-order",
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "ch.fhir.ig.ch-lab-order#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-lab-order/2.0.0"
-    }]
-  },
-  {
-    "name" : "CH eTOC (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-etoc",
-    "description" : "Transition of Care Implementation Guide based on the IPAG report.",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-etoc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-etoc",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-etoc",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 3",
-      "ig-version" : "3.0.0",
-      "package" : "ch.fhir.ig.ch-etoc#3.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-etoc/3.0.0"
-    }]
-  },
-  {
-    "name" : "CH ATC (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-atc",
-    "description" : "The profile CH ATC defines the audit trail consumption requirements for the EPR in Switzerland which a community has to provide for a patients audit trail.",
-    "authority" : "FOPH",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-atc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-atc",
-    "ci-build" : "http://build.fhir.org/ig/ehealthsuisse/ch-atc",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Draft Draft",
-      "ig-version" : "3.3.0",
-      "package" : "ch.fhir.ig.ch-atc#3.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-atc/3.3.0"
-    }]
-  },
-  {
-    "name" : "Observations of notifiable communicable infectious diseases",
-    "category" : "Medication / Immunization",
-    "npm-name" : "ch.fhir.ig.ch-elm",
-    "description" : "CH ELM is a project of the Swiss Federal Office of Public Health (FOPH), Communicable Diseases Division, to enable laboratories to send their observations of notifiable communicable infectious diseases to the FOPH electronically.",
-    "authority" : "FOPH",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-elm/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-elm",
-    "ci-build" : "http://build.fhir.org/ig/ahdis/ch-elm/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.7.0",
-      "package" : "ch.fhir.ig.ch-elm#1.7.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-elm/1.7.0"
-    }]
-  },
-  {
-    "name" : "CH LAB-Report (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-lab-report",
-    "description" : "Implementation Guide for Laboratory Reports in Switzerland.",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-lab-report/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-lab-report",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-lab-report",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "ch.fhir.ig.ch-lab-report#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-lab-report/1.0.0"
-    }]
-  },
-  {
-    "name" : "FHIR eMedication exchange formats for the implementation effort of CARA within its EPR community",
-    "category" : "Medications / Immunizations",
-    "npm-name" : "ch.fhir.ig.ch-emed-epr",
-    "description" : "FHIR eMedication exchange formats for the implementation effort of CARA within its EPR community.",
-    "authority" : "CARA",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-emed-epr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-emed-epr",
-    "ci-build" : "http://build.fhir.org/ig/CARA-ch/ch-emed-epr",
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "ch.fhir.ig.ch-emed-epr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-emed-epr/1.0.0"
-    }]
-  },
-  {
-    "name" : "CH Term (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-term",
-    "description" : "FHIR implementation guide containing terminology that is used in Switzerland for the core profiles, various exchange formats and also in the context of the Swiss electronic patient record (EPR).",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-term/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-term",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-term",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU",
-      "ig-version" : "3.1.0",
-      "package" : "ch.fhir.ig.ch-term#3.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-term/3.1.0"
-    }]
-  },
-  {
-    "name" : "CH EPR FHIR (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-epr-fhir",
-    "description" : "This national extension provides a FHIR based API for the Swiss EPR by extending the IHE FHIR based mobile profiles.",
-    "authority" : "FOPH",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-epr-fhir/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-epr-fhir",
-    "ci-build" : "http://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "DSTU 4",
-      "ig-version" : "4.0.1",
-      "package" : "ch.fhir.ig.ch-epr-fhir#4.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-epr-fhir/4.0.1"
-    }]
-  },
-  {
-    "name" : "CH IPS (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-ips",
-    "description" : "Swiss IPS based on the International Patient Summary Implementation Guide.",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-ips/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-ips",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-ips/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "ch.fhir.ig.ch-ips#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-ips/1.0.0"
-    }]
-  },
-  {
-    "name" : "CH RAD-Order (R4)",
-    "category" : "National Base",
-    "npm-name" : "ch.fhir.ig.ch-rad-order",
-    "description" : "Based on the CH ORF Implementation Guide for Order & Referral in the Radiology domain to achieve a syntactical and semantically consistent cross enterprise information exchange.",
-    "authority" : "HL7 Switzerland",
-    "country" : "ch",
-    "history" : "http://fhir.ch/ig/ch-rad-order/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ch/ig/ch-rad-order",
-    "ci-build" : "http://build.fhir.org/ig/hl7ch/ch-rad-order",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2",
-      "ig-version" : "2.0.0",
-      "package" : "ch.fhir.ig.ch-rad-order#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ch/ig/ch-rad-order/2.0.0"
-    }]
-  },
-  {
-    "name" : "HL7® Austria FHIR® Core Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "hl7.at.fhir.core.r5",
-    "description" : "A FHIR® Implementation Guide for the HL7® Austria FHIR® Core Profiles.",
-    "authority" : "HL7 Austria",
-    "country" : "at",
-    "history" : "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0",
-    "ci-build" : "http://build.fhir.org/ig/HL7Austria/HL7-AT-FHIR-Core-R5",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.at.fhir.core.r5#2.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0/2.0.0"
-    }]
-  },
-  {
-    "name" : "HL7® Austria FHIR® Core Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "hl7.at.fhir.core.r4",
-    "description" : "A FHIR® Implementation Guide for the HL7® Austria FHIR® Core Profiles.",
-    "authority" : "HL7 Austria",
-    "country" : "at",
-    "history" : "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1",
-    "ci-build" : "http://build.fhir.org/ig/HL7Austria/HL7-AT-FHIR-Core-R4",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU2",
-      "ig-version" : "2.0.0",
-      "package" : "hl7.at.fhir.core.r4#2.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/2.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Terminology Ecosystem IG",
-    "category" : "Infrastructure",
-    "npm-name" : "hl7.fhir.uv.tx-ecosystem",
-    "description" : "Terminology Ecosystem documentation and test cases",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/tx-ecosystem/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/tx-ecosystem",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-tx-ecosystem-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases Informative",
-      "ig-version" : "1.8.0",
-      "package" : "hl7.fhir.uv.tx-ecosystem#1.8.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/tx-ecosystem/1.8.0"
-    }]
-  },
-  {
-    "name" : "HL7 FHIR Implementation Guide: DK SMART",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.dk.smart",
-    "description" : "Base danish national implementation guide for SMART",
-    "authority" : "HL7 Denmark",
-    "country" : "dk",
-    "history" : "http://hl7.dk/fhir/smart/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.dk/fhir/smart",
-    "ci-build" : "http://build.fhir.org/ig/hl7dk/dk-smart",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.dk.smart#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.dk/fhir/smart/1.0.0"
-    }]
-  },
-  {
-    "name" : "CDS Hooks Specification",
-    "category" : "Clinical Decision Support",
-    "npm-name" : "hl7.fhir.uv.cds-hooks",
-    "description" : "CDA-Hooks Specification",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://cds-hooks.hl7.org/history.html",
-    "language" : ["en"],
-    "canonical" : "http://cds-hooks.hl7.org",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cds-hooks",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "R3 Ballot",
-      "ig-version" : "3.0.0-ballot",
-      "package" : "hl7.fhir.uv.cds-hooks#3.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://cds-hooks.hl7.org/2026Jan"
-    }]
-  },
-  {
-    "name" : "CDS Hooks Hook Library",
-    "category" : "Clinical Decision Support",
-    "npm-name" : "hl7.fhir.uv.cds-hooks-library",
-    "description" : "CDS Hooks Hook Library",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://cds-hooks.hl7.org/hooks/history.html",
-    "language" : ["en"],
-    "canonical" : "http://cds-hooks.hl7.org/hooks",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cds-hooks-library",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.1",
-      "package" : "hl7.fhir.uv.cds-hooks-library#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://cds-hooks.hl7.org/hooks/STU1"
-    }]
-  },
-  {
-    "name" : "NIHDI Terminology Profiles for Belgium",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.be.nihdi-terminology",
-    "description" : "NIHDI Terminology Profiles for Belgium",
-    "authority" : "eHealth Platform (BE)",
-    "country" : "be",
-    "history" : "https://www.ehealth.fgov.be/standards/fhir/nihdi-terminology/history.html",
-    "language" : ["en"],
-    "canonical" : "https://www.ehealth.fgov.be/standards/fhir/nihdi-terminology",
-    "ci-build" : "http://build.fhir.org/ig/hl7-be/nihdi-terminology",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Trial Use",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.be.nihdi-terminology#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://www.ehealth.fgov.be/standards/fhir/nihdi-terminology/1.0.0"
-    }]
-  },
-  {
-    "name" : "PACIO Transitions of Care Implementation Guide",
-    "category" : "Clinical Documents",
-    "npm-name" : "hl7.fhir.us.pacio-toc",
-    "description" : "Transitions of Care Implementation Guide",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pacio-toc/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pacio-toc",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-transitions-of-care-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.pacio-toc#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pacio-toc/2025May"
-    }]
-  },
-  {
-    "name" : "US Situational Awareness Framework for Reporting (US SAFR) Implementation Guide",
-    "category" : "Public Health",
-    "npm-name" : "hl7.fhir.us.safr",
-    "description" : "Situational Awareness Framework for Reporting (US SAFR)",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/safr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/safr",
-    "ci-build" : "http://build.fhir.org/ig/HL7/us-safr",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.us.safr#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/safr/STU1"
-    }]
-  },
-  {
-    "name" : "Person-Centered Outcomes (PCO) Implementation Guide",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.us.pco",
-    "description" : "Person-Centered Outcomes (PCO) Implementation Guide",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pco/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pco",
-    "ci-build" : "http://build.fhir.org/ig/HL7/pco-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.pco#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pco/2025May"
-    }]
-  },
-  {
-    "name" : "Continuous Glucose Monitoring",
-    "category" : "Diagnostics",
-    "npm-name" : "hl7.fhir.uv.cgm",
-    "description" : "Continuous Glucose Monitoring",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cgm/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cgm",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cgm",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.cgm#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cgm/STU1"
-    }]
-  },
-  {
-    "name" : "Common CQL Assets for FHIR (US-Based)",
-    "category" : "Quality/CDS",
-    "npm-name" : "hl7.fhir.us.cql",
-    "description" : "Common CQL Assets for FHIR",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/cql/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/cql",
-    "ci-build" : "http://build.fhir.org/ig/HL7/us-cql-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Informative 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.cql#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cql/2026May"
-    }]
-  },
-  {
-    "name" : "Clinical Order Workflows",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.uv.cow",
-    "description" : "Clinical Order Workflows",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cow/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cow",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-cow-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.cow#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/cow/2025May"
-    }]
-  },
-  {
-    "name" : "HL7 Electronic Health Record System Functional Model, Release 2.1.1",
-    "category" : "EHR-S Family",
-    "npm-name" : "hl7.ehrs.uv.ehrsfmr2",
-    "description" : "Electronic Health Record System Functional Model",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/ehrs/uv/ehrsfmr2/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/ehrs/uv/ehrsfmr2",
-    "ci-build" : "http://build.fhir.org/ig/HL7/ehrsfm-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Normative 1 Ballot",
-      "ig-version" : "2.1.1-ballot",
-      "package" : "hl7.ehrs.uv.ehrsfmr2#2.1.1-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/ehrs/uv/ehrsfmr2/2025May"
-    }]
-  },
-  {
-    "name" : "HL7 Personal Health Record System Functional Model, Release 2",
-    "category" : "EHR-S Family",
-    "npm-name" : "hl7.ehrs.uv.phrsfmr2",
-    "description" : "Personal Health Record System Functional Model",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/ehrs/uv/phrsfmr2/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/ehrs/uv/phrsfmr2",
-    "ci-build" : "http://build.fhir.org/ig/HL7/phrsfm-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Normative 1 Ballot",
-      "ig-version" : "2.0.1-ballot",
-      "package" : "hl7.ehrs.uv.phrsfmr2#2.0.1-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/ehrs/uv/phrsfmr2/2025May"
-    }]
-  },
-  {
-    "name" : "MyHealth@Eu Laboratory Report",
-    "category" : "Laboratory Report",
-    "npm-name" : "myhealth.eu.fhir.laboratory",
-    "description" : "MyHealth@EU Laboratory Report Implementaion Guide for European Cross border services.",
-    "authority" : "eHMSEG STF Architecture WG",
-    "country" : "eu",
-    "history" : "http://fhir.ehdsi.eu/laboratory/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.ehdsi.eu/laboratory",
-    "ci-build" : "https://build-fhir.ehdsi.eu/laboratory",
-    "editions" : [{
-      "name" : "MyHealth@EU wave 8 trial use release",
-      "ig-version" : "0.1.1",
-      "package" : "myhealth.eu.fhir.laboratory#0.1.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.ehdsi.eu/laboratory/0.1.1"
-    }]
-  },
-  {
-    "name" : "Dk Terminology for XDS Metadata",
-    "category" : "Clinical Documents",
-    "npm-name" : "medcom.fhir.dk.xdsmetadata",
-    "description" : "MedCom Terminology for XDS Metadata",
-    "authority" : "MedCom",
-    "country" : "dk",
-    "history" : "http://medcomfhir.dk/ig/xdsmetadata/history.html",
-    "language" : ["en"],
-    "canonical" : "http://medcomfhir.dk/ig/xdsmetadata",
-    "ci-build" : "http://build.fhir.org/ig/medcomdk/dk-medcom-xds-metadata",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release",
-      "ig-version" : "1.0.1",
-      "package" : "medcom.fhir.dk.xdsmetadata#1.0.1",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/xdsmetadata/1.0.1"
-    },
-    {
-      "name" : "Release",
-      "ig-version" : "1.0.0",
-      "package" : "medcom.fhir.dk.xdsmetadata#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://medcomfhir.dk/ig/xdsmetadata/1.0.0"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Base and Core (R4)",
-    "category" : "Regional Base",
-    "npm-name" : "hl7.fhir.eu.base",
-    "description" : "This guide lists the base and core profiles - FHIR R4 - specified for the European REALM.",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/base/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/base",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/base",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2.0 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.eu.base#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/base/0.1.0"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Base and Core (R5)",
-    "category" : "Regional Base",
-    "npm-name" : "hl7.fhir.eu.base-r5",
-    "description" : "This guide lists the base and core profiles  - FHIR R5 - specified for the European REALM.",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/base-r5/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/base-r5",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/base-r5",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 2.0 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.eu.base-r5#2.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.eu/fhir/base-r5/0.1.0"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Imaging Study Report",
-    "category" : "Imaging",
-    "npm-name" : "hl7.fhir.eu.imaging-r5",
-    "description" : "This implementation guide specifies imaging study data in the European context, as defined in eHN Imaging Studies and Reports and refined by XtEHR Imaging Logical Model, as a FHIR model.",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/imaging-r5/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/imaging-r5",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/imaging-r5",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.eu.imaging-r5#1.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.eu/fhir/imaging-r5/1.0.0-ballot"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Imaging Report",
-    "category" : "Imaging",
-    "npm-name" : "hl7.fhir.eu.imaging",
-    "description" : "This implementation guide specifies imaging study data in the European context, as defined in eHN Imaging Studies and Reports and refined by XtEHR Imaging Logical Model, as a FHIR model.",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/imaging/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/imaging",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/imaging-r4",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.eu.imaging#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/imaging/1.0.0-ballot"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Hospital Discharge Report",
-    "category" : "Discharge Report",
-    "npm-name" : "hl7.fhir.eu.hdr",
-    "description" : "This implementation guide specifies the Hospital Discharge Report in the European context, as defined in eHN Hospital Discharge Report guidelines.",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/hdr/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/hdr",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/hdr",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0-ballot",
-      "package" : "hl7.fhir.eu.hdr#0.1.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/hdr/0.1.0-ballot"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Medication Prescription and Dispense",
-    "category" : "Medication Management",
-    "npm-name" : "hl7.fhir.eu.mpd",
-    "description" : "This guide describes how to represent in HL7 FHIR Prescription and Dispense in the European context. (FHIR R4)",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/mpd/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/mpd",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/mpd",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0-ballot",
-      "package" : "hl7.fhir.eu.mpd#0.1.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/mpd/0.1.0-ballot"
-    }]
-  },
-  {
-    "name" : "HL7 Europe Medication Prescription and Dispense",
-    "category" : "Medication Management",
-    "npm-name" : "hl7.fhir.eu.mpd-r5",
-    "description" : "This guide describes how to represent in HL7 FHIR Prescription and Dispense in the European context. (FHIR R5)",
-    "authority" : "HL7 Europe",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/mpd-r5/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/mpd-r5",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/mpd-r5",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "0.1.0-ballot",
-      "package" : "hl7.fhir.eu.mpd-r5#0.1.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.eu/fhir/mpd-r5/0.1.0-ballot"
-    }]
-  },
-  {
-    "name" : "EU Health Data API",
-    "category" : "EHDS",
-    "npm-name" : "hl7.fhir.eu.health-data-api",
-    "description" : "This Implementation Guide defines HL7 FHIR-based APIs for accessing and exchanging health data in the European Health Data Space (EHDS).",
-    "authority" : "Euridice (HL7 Europe,IHE Europe)",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/health-data-api/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/health-data-api",
-    "ci-build" : "http://build.fhir.org/ig/euridice-org/eu-health-data-api",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.eu.health-data-api#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/health-data-api/1.0.0-ballot"
-    }]
-  },
-  {
-    "name" : "xShare Project xShare Project IPS+ Implementation Guide",
-    "category" : "EHDS",
-    "npm-name" : "hl7.eu.fhir.xshare-ips-plus",
-    "description" : "This guide provides instructions to help you understand and implement your product in accordance with the xShare IPS+, facilitating in the access and adoption of the selected specifications.",
-    "authority" : "xShare project",
-    "country" : "eu",
-    "history" : "http://hl7.eu/fhir/ig/xshare-ips-plus/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.eu/fhir/ig/xshare-ips-plus",
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/xshare-ips-plus",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 1 Qa-preview",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.eu.fhir.xshare-ips-plus#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/ig/xshare-ips-plus/0.1.0"
-    }]
-  },
-  {
-    "name" : "xShare Project Yellow Button Implementation Guide",
-    "category" : "EHDS",
-    "npm-name" : "hl7.eu.fhir.xshare-yb",
-    "description" : "xShare envisions everyone sharing their health data in European Electronic Health Record Exchange Format (EEHRxF) with a click-of-a-button - the xShare yellow button - to be featured across health portals and patient apps, allowing people to exercise their data portability rights under GDPR.",
-    "authority" : "xShare project",
-    "country" : "eu",
-    "history" : "https://hl7.eu/fhir/ig/xshare-yb/history.html",
-    "language" : ["en"],
-    "ci-build" : "http://build.fhir.org/ig/hl7-eu/xShare",
-    "canonical" : "http://hl7.eu/fhir/ig/xshare-yb",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1.2",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.eu.fhir.xshare-yb#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.eu/fhir/ig/xshare-yb/0.2.0"
-    }]
-  },
-  {
-    "name" : "Computable Care Guidelines (CCG)",
-    "category" : "Computable Care Guidelines",
-    "npm-name" : "ihe.qrph.ccg",
-    "description" : "The IHE Computable Care Guidelines (CCG) Profile specifies a normative grammar and a normative transaction processing model that allows evidence-based care recommendations to be expressed in a way that a digital health solution can ingest and operationalize. This is an implementable and conformance-testable specification. It is targeted to regulated healthcare markets where the support for multiple conditions is an important requirement. The CCG Profile supports jurisdictions that want to leverage digital health to systemically improve the adoption of guideline-adherent best practices across an entire care delivery network.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/QRPH/CCG/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/QRPH/CCG",
-    "ci-build" : "http://build.fhir.org/ig/IHE/QRPH.CCG",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0",
-      "package" : "ihe.qrph.ccg#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/QRPH/CCG/1.0.0"
-    }]
-  },
-  {
-    "name" : "Medication Prescription and Dispense (MPD)",
-    "category" : "Medication",
-    "npm-name" : "ihe.pharm.mpd",
-    "description" : "The Medication Prescription and Dispense (MPD) profile defines profiles and actors for interoperable systems handling medication ordering and dispensing.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/PHARM/MPD/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/PHARM/MPD",
-    "ci-build" : "http://build.fhir.org/ig/IHE/pharm-mpd/branches/master/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication",
-      "ig-version" : "1.0.0-comment-2",
-      "package" : "ihe.pharm.mpd#1.0.0-comment-2",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://profiles.ihe.net/PHARM/MPD/1.0.0-comment-2"
-    }]
-  },
-  {
-    "name" : "ÚNICAS Rare Diseases HL7 FHIR Implementation Guide",
-    "category" : "Rare Diseases",
-    "npm-name" : "unicas-ig",
-    "description" : "This is the implementation guide for ÚNICAS, a project whose objective is to create an ecosystem of partnerships to improve healthcare for pediatric patients with complex rare diseases. Through the network within the National Health System, the project aims to improve the diagnosis and care of patients with rare diseases. Published by TIC Salut Social, CatSalut Departament de Salut de Catalunya, Sistema Nacional de Salud Ministerio de Sanidad de España",
-    "authority" : "TIC Salut Social",
-    "country" : "es",
-    "history" : "https://unicas-fhir.sanidad.gob.es/history.html",
-    "language" : ["es"],
-    "canonical" : "https://unicas-fhir.sanidad.gob.es",
-    "ci-build" : "https://unicas-fhir.sanidad.gob.es",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Draft",
-      "ig-version" : "0.0.1",
-      "package" : "unicas-ig#0.0.1",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://unicas-fhir.sanidad.gob.es"
-    }]
-  },
-  {
-    "name" : "Medication IG DE",
-    "category" : "National Base",
-    "npm-name" : "de.fhir.medication",
-    "description" : "Developed for the German healthcare context, this specification provides a set of profiles and extensions for medication management, currently focused on Dosage and Timing, based on FHIR R4.",
-    "authority" : "HL7 Deutschland e.V.",
-    "country" : "de",
-    "history" : "http://ig.fhir.de/igs/medication/history.html",
-    "language" : ["de"],
-    "canonical" : "http://ig.fhir.de/igs/medication",
-    "ci-build" : "http://build.fhir.org/ig/hl7germany/medication-ig-de-r4",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "de.fhir.medication#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://ig.fhir.de/igs/medication/1.0.0-ballot"
-    }]
-  },
-  {
-    "name" : "Vulcan FHIR to OMOP FHIR Implementation Guide",
-    "category" : "research",
-    "npm-name" : "hl7.fhir.uv.omop",
-    "description" : "This IG delivers FHIR‑to‑OMOP Logical Models, StructureMaps, and pragmatic, hands‑on implementer guidance, enabling you to: Transform data uniformly with minimal information loss, Accelerate observational research and real‑world‑evidence generation with FHIR, and Cut costs and time through faster, more consistent ETL pipelines",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/omop/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/omop",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-omop",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "INFORMATIVE 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.omop#1.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/omop/2025Sep"
-    }]
-  },
-  {
-    "name" : "CardX - Cardiac Implantable Electronic Devices",
-    "category" : "Care Management",
-    "npm-name" : "hl7.fhir.uv.cardx-cied",
-    "description" : "The CardX - Cardiac Implantable Electronic Devices IG defines universal standards to enable interoperable data exchange for CIED use cases and data. The IG consists of FHIR profiles, extensions, transactions, and value sets needed to represent, query for, and exchange data for evidence-based management of CIED patients.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/cardx-cied/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/cardx-cied",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cardx-cied",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.cardx-cied#1.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/fhir/uv/cardx-cied/2025Sep"
-    }]
-  },
-  {
-    "name" : "Pharmaceutical Clinical Trial Protocols",
-    "category" : "Research",
-    "npm-name" : "hl7.fhir.uv.pharmaceutical-research-protocol",
-    "description" : "The IG covers a range of use cases for digital representation of a Clinical Trial protocol.   The simplest use case is document oriented submission of a protocol to a Regulator. Complex use cases require detailed machine processable representation of a protocol.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/pharmaceutical-research-protocol/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/pharmaceutical-research-protocol",
-    "ci-build" : "https://github.com/HL7/vulcan-udp-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.pharmaceutical-research-protocol#1.0.0-ballot",
-      "fhir-version" : ["6.0.0"],
-      "url" : "http://hl7.org/fhir/uv/pharmaceutical-research-protocol/2025Sep"
-    }]
-  },
-  {
-    "name" : "Data Exchange Profiles for 2022 CDC Clinical Practice Guideline for Prescribing Opioids",
-    "category" : "Quality/CDS",
-    "npm-name" : "hl7.fhir.us.cdc-opioid-cpg",
-    "description" : "Defines exchange expectations for systems that implement the CDC's Clinical Practice Guideline for Prescribing Opioids, both in terms of the data required to evaluate whether recommendations are applicable, as well as the data required to represent proposals resulting from those recommendations.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/cdc-opioid-cpg/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/cdc-opioid-cpg",
-    "ci-build" : "http://build.fhir.org/ig/HL7/cdc-opioid-cpg",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.cdc-opioid-cpg#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/cdc-opioid-cpg/2025Sep"
-    }]
-  },
-  {
-    "name" : "HL7 Informative Document: Patient Information Quality Improvement (PIQI) Framework, Edition 1",
-    "category" : "Frameworks",
-    "npm-name" : "hl7.xprod.uv.piqi",
-    "description" : "The Patient Information Quality Improvement Framework or PIQI Framework (pronounced ‘picky’) creates a standard approach to evaluating data quality of patient-centric healthcare information. PIQI prioritizes portability and reusability, enabling seamless integration into various systems irrespective of the data source.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/xprod/ig/uv/piqi/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/xprod/ig/uv/piqi",
-    "ci-build" : "http://build.fhir.org/ig/HL7/piqi",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Informative 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.xprod.uv.piqi#1.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/xprod/ig/uv/piqi/2025Sep"
-    }]
-  },
-  {
-    "name" : "US HR1 Medicaid Work Requirements IG (proposed, not supported by CMS)",
-    "npm-name" : "cori.fhir.ig.wrig",
-    "category" : "Care Management",
-    "description" : "Profiles and implementation details for US HR1 Medicaid Work Requirements exemption and activity verification.",
-    "authority" : "Cori System Organization",
-    "country" : "us",
-    "history" : "https://wrig.corisystem.org",
-    "ci-build" : "https://build.fhir.org/ig/arosearose3/wrig",
-    "editions" : [{
-      "name" : "0.1.0",
-      "ig-version" : "0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "package" : "cori.fhir.ig.wrig#0.1.0",
-      "url" : "https://wrig.corisystem.org"
-    }]
-  },
-  {
-    "name" : "US Behavioral Health Profiles",
-    "category" : "Care Management",
-    "npm-name" : "fhir.astp.bhp",
-    "description" : "The United States Core Data for Interoperability (USCDI) Plus Behavioral Health (BH) dataset (also referred to as USCDI+ BH) aims to enhance the exchange and interoperability of behavioral health information across healthcare systems in the United States. Building on the USCDI foundation, this dataset addresses the unique needs and challenges associated with behavioral health data. It is designed to facilitate behavioral health integration with other healthcare services, support better clinical decision-making, and improve patient outcomes.",
-    "authority" : "US Government",
-    "country" : "us",
-    "history" : "http://fhir.org/guides/astp/bhp/history.html",
-    "language" : ["en"],
-    "canonical" : "http://fhir.org/guides/astp/bhp",
-    "ci-build" : " http://build.fhir.org/guides/astp/bhp",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "0.1.0",
-      "ig-version" : "0.1.0",
-      "package" : "fhir.astp.bhp#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.org/guides/astp/bhp/0.1.0"
-    }]
-  },
-  {
-    "name" : "Csiro Stars",
-    "category" : "Diagnostics",
-    "npm-name" : "csiro.stars",
-    "description" : "The STARS network provides restricted sample submission. This implementation guide outlines the requirements for users to implement a common standard FHIR protocol to transfer specimen information between laboratories for the purpose of testing.",
-    "authority" : "CSIRO",
-    "country" : "au",
-    "history" : "https://starsapi.csiro.au/fhir-ig/stars/history.html",
-    "language" : ["en"],
-    "canonical" : "https://starsapi.csiro.au/fhir-ig/stars",
-    "ci-build" : "https://starsapi.csiro.au/fhir-ig/stars",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Releases",
-      "ig-version" : "0.5.1",
-      "package" : "csiro.stars#0.5.1",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://starsapi.csiro.au/fhir-ig/stars/0.5.1"
-    }]
-  },
-  {
-    "name" : "PL Base (R5)",
-    "category" : "Regional Base",
-    "npm-name" : "hl7.fhir.pl.base.r5",
-    "description" : "This guide lists the base profiles specified for the Polish realm.",
-    "authority" : "HL7 Poland",
-    "country" : "pl",
-    "history" : "https://hl7.org.pl/fhir/ig/pl-base/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org.pl/fhir/ig/pl-base/ImplementationGuide/Hl7PlBaseIg",
-    "ci-build" : "http://build.fhir.org/ig/HL7-Poland/pl-fhir-base",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "0.1.2",
-      "package" : "hl7.fhir.pl.base.r5#0.1.2",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://hl7.org.pl/ig/pl-base/0.1.2"
-    }]
-  },
-  {
-    "name" : "Bangladesh FHIR Implementation Guide - Core Profiles",
-    "category" : "National Base",
-    "npm-name" : "bd.fhir.core",
-    "description" : "National base profiles, CodeSystems, and ValueSets for Bangladesh, developed and maintained by the Directorate General of Health Services (DGHS), Ministry of Health and Family Welfare.",
-    "authority" : "DGHS Bangladesh",
-    "product" : ["fhir"],
-    "country" : "bd",
-    "history" : "https://fhir.dghs.gov.bd/core/history.html",
-    "language" : ["en"],
-    "canonical" : "https://fhir.dghs.gov.bd/core",
-    "ci-build" : "https://fhir.dghs.gov.bd/core",
-    "editions" : [{
-      "name" : "Draft 0.2.0",
-      "ig-version" : "0.2.0",
-      "package" : "bd.fhir.core#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://fhir.dghs.gov.bd/core"
-    }]
-  },
-  {
-    "name" : "SQL on FHIR",
-    "category" : "Infrastructure",
-    "npm-name" : "org.sql-on-fhir.ig",
-    "description" : "A specification for defining portable views of FHIR data that can be easily queried using tools such as SQL.",
-    "authority" : "SQL on FHIR Working Group",
-    "country" : "uv",
-    "history" : "https://sql-on-fhir.org/ig/history.html",
-    "language" : ["en"],
-    "canonical" : "https://sql-on-fhir.org/ig",
-    "ci-build" : "https://build.fhir.org/ig/FHIR/sql-on-fhir-v2",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "2.0.0",
-      "ig-version" : "2.0.0",
-      "package" : "org.sql-on-fhir.ig#2.0.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://sql-on-fhir.org/ig/2.0.0"
-    }]
-  },
-  {
-    "name" : "Advance Care Planning (PZP)",
-    "category" : "Care Management",
-    "npm-name" : "iknl.fhir.r4.pzp",
-    "description" : "This implementation guide supports the Advance Care Planning (ACP) information standard (Dutch: Proactieve Zorgplanning) and is intended for use within the palliative care domain in the Netherlands.",
-    "authority" : "IKNL",
-    "country" : "nl",
-    "history" : "https://api.iknl.nl/docs/pzp/r4/history.html",
-    "language" : ["en"],
-    "canonical" : "https://api.iknl.nl/docs/pzp/r4",
-    "ci-build" : "http://build.fhir.org/ig/IKNL/PZP-FHIR-R4/branches/develop",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0-rc2",
-      "package" : "iknl.fhir.r4.pzp#1.0.0-rc2",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://api.iknl.nl/docs/pzp/r4/1.0.0-rc2"
-    }]
-  },
-  {
-    "name" : "Advance Care Planning (PZP)",
-    "category" : "Care Management",
-    "npm-name" : "iknl.fhir.stu3.pzp",
-    "description" : "This implementation guide supports the Advance Care Planning (ACP) information standard (Dutch: Proactieve Zorgplanning) and is intended for use within the palliative care domain in the Netherlands.",
-    "authority" : "IKNL",
-    "country" : "nl",
-    "history" : "https://api.iknl.nl/docs/pzp/stu3/history.html",
-    "language" : ["en"],
-    "canonical" : "https://api.iknl.nl/docs/pzp/stu3",
-    "ci-build" : "http://build.fhir.org/ig/IKNL/PZP-FHIR-STU3/branches/develop",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "1.0.0-rc2",
-      "package" : "iknl.fhir.stu3.pzp#1.0.0-rc2",
-      "fhir-version" : ["3.0.2"],
-      "url" : "https://api.iknl.nl/docs/pzp/stu3/1.0.0-rc2"
-    }]
-  },
-  {
-    "name" : "FLC Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "flc.fhir.base",
-    "description" : "Implementationsguide for FLC made by Service Well",
-    "authority" : "Service Well",
-    "country" : "uv",
-    "history" : "http://canonical.fhir.link/flc/base/history.html",
-    "language" : ["en"],
-    "canonical" : "http://canonical.fhir.link/flc/base",
-    "ci-build" : "http://build.fhir.org/ig/servicewell/flc.fhir.base",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Pre-Release Draft",
-      "ig-version" : "0.2.4",
-      "package" : "flc.fhir.base#0.2.4",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://canonical.fhir.link/flc/base/0.2.4"
-    }]
-  },
-  {
-    "name" : "ONCOFAIR FHIR Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "ltsi.fhir.oncofair",
-    "description" : "The OncoFAIR project is designed to improve the interoperability and reuse of healthcare data in oncology, focusing on chemotherapy.",
-    "authority" : "KEREVAL, LTSI",
-    "country" : "fr",
-    "history" : "http://oncofair-ig.kereval.cloud/ltsi.fhir.oncofair/history.html",
-    "language" : ["en"],
-    "ci-build" : "https://oncofair.github.io/FHIR-ImplementationGuide-Article/main/ig",
-    "canonical" : "http://oncofair-ig.kereval.cloud",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "final-text",
-      "ig-version" : "0.1.0",
-      "package" : "ltsi.fhir.oncofair#0.1.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://oncofair-ig.kereval.cloud/ltsi.fhir.oncofair"
-    }]
-  },
-  {
-    "name" : "Basic National Terminology for Costa Rica",
-    "category" : "Terminology",
-    "npm-name" : "hl7.fhir.cr.terminology",
-    "description" : "This implementation guide defines the FHIR terminology resources used by the HL7 Costa Rica Initiative.",
-    "authority" : "HL7 Initiative in Costa Rica",
-    "country" : "cr",
-    "history" : "https://hl7.or.cr/fhir/terminology/history.html",
-    "language" : ["es"],
-    "canonical" : "https://hl7.or.cr/fhir/terminology",
-    "ci-build" : "http://build.fhir.org/ig/HL7-cr/terminology",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Draft 0.0.1",
-      "ig-version" : "0.0.1-ballot",
-      "package" : "hl7.fhir.cr.terminology#0.0.1-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "https://hl7.or.cr/fhir/terminology/0.0.1-ballot"
-    }]
-  },
-  {
-    "name" : "WOF Connect Implementation Guide",
-    "category" : "Infrastructure",
-    "npm-name" : "servicewell.fhir.wof-connect",
-    "description" : "Well On FHIR (WOF) is Service Well AB’s initiative to provide shared FHIR APIs for healthcare. This wof.connect Implementation Guide defines the WOF Connect API and is part of a growing family of WOF IGs, including a forthcoming platform-level FHIR API (wof.platform) and other Service Well-authored guides.",
-    "authority" : "Service Well",
-    "country" : "uv",
-    "history" : "http://canonical.fhir.link/servicewell/wof-connect/history.html",
-    "language" : ["en"],
-    "canonical" : "http://canonical.fhir.link/servicewell/wof-connect",
-    "ci-build" : "http://build.fhir.org/ig/servicewell/servicewell.fhir.wof-connect",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Pre-Release Draft",
-      "ig-version" : "0.1.0",
-      "package" : "servicewell.fhir.wof-connect#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://canonical.fhir.link/servicewell/wof-connect/0.1.0"
-    }]
-  },
-  {
-    "name" : "AI Transparency on FHIR",
-    "category" : "AI",
-    "npm-name" : "hl7.fhir.uv.aitransparency",
-    "description" : "Healthcare systems increasingly use artificial intelligence to process patient data. This IG defines a standard way to communicate when and how AI was involved to downstream users. This track enables participants to implement transparent labeling and documentation of AI usage in healthcare data exchanges, ensuring clinicians and patients can make informed decisions about AI-influenced information",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/aitransparency/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/aitransparency",
-    "ci-build" : "http://build.fhir.org/ig/HL7/aitransparency-ig/branches/main/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.aitransparency#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/aitransparency/2026Jan"
-    }]
-  },
-  {
-    "name" : "HL7 Czech FHIR Terminology",
-    "category" : "Terminology",
-    "npm-name" : "hl7.fhir.cz.terminology",
-    "description" : "HL7 and NCEZ FHIR Terminology for the Czech Republic.",
-    "authority" : "HL7 Czech Republic",
-    "country" : "cz",
-    "history" : "https://hl7.cz/terminology/history.html",
-    "language" : ["en"],
-    "canonical" : "https://hl7.cz/terminology",
-    "ci-build" : "http://build.fhir.org/ig/HL7-cz/terminology",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Release 1",
-      "ig-version" : "0.2.0",
-      "package" : "hl7.fhir.cz.terminology#0.2.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.cz/terminology/0.2.0"
-    }]
-  },
-  {
-    "name" : "Phenomics Exchange for Research and Diagnostics",
-    "category" : "Clinical Observations",
-    "npm-name" : "hl7.fhir.uv.phenomics-exchange",
-    "description" : "This Implementation Guide provides conformance resources to support the authoring and exchange of the phenotypic picture of an individual or a group of individuals.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/phenomics-exchange/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/phenomics-exchange",
-    "ci-build" : "http://build.fhir.org/ig/HL7/phenomics-exchange-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.uv.phenomics-exchange#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/phenomics-exchange/2026Jan"
-    }]
-  },
-  {
-    "name" : "Scalable Consent Management",
-    "category" : "Privacy / Security",
-    "npm-name" : "hl7.fhir.us.consent-management",
-    "description" : "Patient Consent management is the central component in a consent ecosystem and at the core of a scalable consent architecture.  This guide provides operations and profiles to enable the answering the question `is it possible to answer the question provider X have authority to view healthcare data Y about patient Z?` across a set of consent management repositories.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/consent-management/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/consent-management",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-consent-management",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.consent-management#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/consent-management/2026Jan"
-    }]
-  },
-  {
-    "name" : "Documentation des guides d'implémentation de l'ANS",
-    "category" : "Documentation",
-    "npm-name" : "ans.fr.documentation",
-    "description" : "Documentation des guides d'implémentation de l'ANS",
-    "authority" : "ANS (FR)",
-    "country" : "fr",
-    "history" : "https://interop.esante.gouv.fr/ig/documentation/history.html",
-    "language" : ["en"],
-    "canonical" : "https://interop.esante.gouv.fr/ig/documentation",
-    "ci-build" : "https://ansforge.github.io/IG-documentation/ig/main",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "release",
-      "ig-version" : "0.1.10",
-      "package" : "ans.fr.documentation#0.1.10",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://interop.esante.gouv.fr/ig/documentation/0.1.10"
-    }]
-  },
-  {
-    "name" : "Symptoms Data Standards",
-    "category" : "Clinical",
-    "npm-name" : "hl7.fhir.uv.symptoms",
-    "description" : "This Implementation Guide defines how to represent and exchange standardized symptom data using FHIR to support improved diagnostic accuracy and patient outcomes. It is intended for EHR vendors, developers, and implementers who need to capture and share symptom information consistently across systems and care settings.",
-    "authority" : "HL7",
-    "country" : "uv",
-    "history" : "http://hl7.org/fhir/uv/symptoms/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/uv/symptoms",
-    "ci-build" : "http://build.fhir.org/ig/HL7/fhir-symptoms-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.fhir.uv.symptoms#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/uv/symptoms/STU1"
-    }]
-  },
-  {
-    "name" : "HL7 EHR-S FM R2.1.1 - Dental Health Functional Profile, Release 2",
-    "category" : "EHR-S Family",
-    "npm-name" : "hl7.ehrs.us.dhfpr2",
-    "description" : "The DHFP is based on the HL7 Electronic Health Record System Functional Model and Standard (EHR-S FM) Release 2.01, July 2017. The DHFP is intended to inform software developers, users, purchasers, and other interested parties, such as payers and data aggregators, regarding the desired performance of a dental electronic health record software system, whether operating stand-alone or integrated with a medical electronic health record system. The DHFP is an informative technical report intended for use in the United States Realm",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/ehrs/us/dhfpr2/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/ehrs/us/dhfpr2",
-    "ci-build" : "http://build.fhir.org/ig/HL7/dhfp-ig",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Informative Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.ehrs.us.dhfpr2#2.0.0-ballot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://hl7.org/ehrs/us/dhfpr2/2026Jan"
-    }]
-  },
-  {
-    "name" : "Generic Functions for data exchange Implementation Guide",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.nl.gf",
-    "description" : "This implementation guide specifies generic functions needed for (use case specific) data exchange standards in the Netherlands. These functions cover identification, authentication, authorization, data localization, consent and a care service directory.",
-    "authority" : "Ministry of Health, Welfare and Sport",
-    "country" : "nl",
-    "history" : "https://minvws.github.io/generiekefuncties-docs/history.html",
-    "language" : ["en"],
-    "canonical" : "http://minvws.github.io/generiekefuncties-docs",
-    "ci-build" : "https://build.fhir.org/ig/minvws/generiekefuncties-docs",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Ballot 1",
-      "ig-version" : "0.2.0-ballot",
-      "package" : "hl7.fhir.nl.gf#0.2.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://build.fhir.org/ig/minvws/generiekefuncties-docs/branches/0.2.0-ballot"
-    },
-    {
-      "name" : "release for hl7-nl validation",
-      "ig-version" : "0.1.0",
-      "package" : "hl7.fhir.nl.gf#0.1.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://build.fhir.org/ig/minvws/generiekefuncties-docs/branches/v0.1.0"
-    }]
-  },
-  {
-    "name" : "Médicosocial - Transfert de données DUI",
-    "category" : "Clinical Documents",
-    "npm-name" : "ans.fhir.fr.tddui",
-    "description" : "Clinical Documents",
-    "authority" : "ANS (FR)",
-    "country" : "fr",
-    "history" : "https://interop.esante.gouv.fr/ig/fhir/tddui/history.html",
-    "language" : ["en"],
-    "canonical" : "https://interop.esante.gouv.fr/ig/fhir/tddui",
-    "ci-build" : "https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/ig/main",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "public-comment",
-      "ig-version" : "2.2.0-ballot",
-      "package" : "ans.fhir.fr.tddui#2.2.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://interop.esante.gouv.fr/ig/fhir/tddui/2.2.0-ballot"
-    }]
-  },
-  {
-    "name" : "Base openEHR specification",
-    "category" : "Infrastructure",
-    "npm-name" : "openehr.base",
-    "description" : "openEHR Base specification",
-    "authority" : "openEHR",
-    "country" : "uv",
-    "history" : "http://openehr.org/fhir/history.html",
-    "language" : ["en"],
-    "canonical" : "http://openehr.org/fhir",
-    "ci-build" : "http://build.fhir.org/ig/openehr-fhir/base-spec",
-    "product" : ["openehr"],
-    "editions" : [{
-      "name" : "Release Informative",
-      "ig-version" : "0.1.0-snapshot",
-      "package" : "openehr.base#0.1.0-snapshot",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://fhir.org/guides/openehr/base/0.1.0-snapshot"
-    }]
-  },
-  {
-    "name" : "Czech National FHIR R4 Core and Base Implementation Guide STU 1",
-    "category" : "National Base",
-    "npm-name" : "hl7.fhir.cz.core",
-    "description" : "This implementation guide specifies Base and core profiles used by Czech Republic national interoperability project.",
-    "authority" : "HL7 Czech Republic",
-    "country" : "cz",
-    "history" : "https://hl7.cz/fhir/core/history.html",
-    "language" : ["en"],
-    "canonical" : "https://hl7.cz/fhir/core",
-    "ci-build" : "http://build.fhir.org/ig/HL7-cz/cz-core",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1",
-      "ig-version" : "0.3.0",
-      "package" : "hl7.fhir.cz.core#0.3.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://hl7.cz/fhir/core/0.3.0"
-    }]
-  },
-  {
-    "name" : "Austrian Patient Summary (R4)",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.at.fhir.elga.aps.r4",
-    "description" : "The FHIR® implementation guide Austrian Patient Summary is derived from the HL7® Austria FHIR® Core implementation guide and ensures conformity with the International Patient Summary (IPS).",
-    "authority" : "ELGA GmbH",
-    "country" : "at",
-    "history" : "https://fhir.hl7.at/elga/aps/r4/history.html",
-    "language" : ["en"],
-    "canonical" : "https://fhir.hl7.at/elga/aps/r4",
-    "ci-build" : "http://build.fhir.org/ig/HL7Austria/ELGA-AustrianPatientSummary-R4",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU1",
-      "ig-version" : "1.0.0",
-      "package" : "hl7.at.fhir.elga.aps.r4#1.0.0",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://fhir.hl7.at/elga/aps/r4/1.0.0"
-    }]
-  },
-  {
-    "name" : "FHIR International Patient Summary (FIPS)",
-    "category" : "Content Profile",
-    "npm-name" : "ihe.pcc.fiio",
-    "description" : "Additional options for implementing the HL7 International Patient Summary FHIR document and associated testing requirements.",
-    "authority" : "IHE",
-    "country" : "uv",
-    "history" : "https://profiles.ihe.net/PCC/FIIO/history.html",
-    "language" : ["en"],
-    "canonical" : "https://profiles.ihe.net/PCC/FIIO",
-    "ci-build" : "http://build.fhir.org/ig/IHE/PCC.FIIO/branches/master/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Publication Ballot",
-      "ig-version" : "1.0.0-comment",
-      "package" : "ihe.pcc.fiio#1.0.0-comment",
-      "fhir-version" : ["4.0.1"],
-      "url" : "https://profiles.ihe.net/PCC/FIIO/1.0.0-comment"
-    }]
-  },
-  {
-    "name" : "EHDS Logical Information Models",
-    "category" : "EHDS",
-    "npm-name" : "xtehr.eu.ehds.models",
-    "description" : "This is the second preview version of the EHDS Logical Information Models proposed by the Xt-EHR Joint Action.",
-    "authority" : "Xt-EHR Joint Action",
-    "country" : "eu",
-    "history" : "http://www.xt-ehr.eu/fhir/models/history.html",
-    "language" : ["en"],
-    "canonical" : "http://www.xt-ehr.eu/fhir/models",
-    "ci-build" : "http://build.fhir.org/ig/Xt-EHR/xt-ehr-common",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Edition 1 Preview",
-      "ig-version" : "0.3.0",
-      "package" : "xtehr.eu.ehds.models#0.3.0",
-      "fhir-version" : ["5.0.0"],
-      "url" : "http://www.xt-ehr.eu/fhir/models/0.3.0"
-    }]
-  },
-  {
-    "name" : "Bulk Retrieval of Public Health Data",
-    "category" : "Public Health",
-    "npm-name" : "hl7.fhir.us.ph-bulk-data",
-    "description" : "The Bulk FHIR data access IG facilitates the sharing of data on populations of individuals and is a Priority Area for the Helios FHIR Accelerator for Public Health. This approach allows users of Electronic Health Records (EHR) systems and other electronic platforms to utilize the carefully curated data managed by public health programs. By implementing FHIR Bulk data, authorized users can efficiently retrieve data for defined groups through a standardized and reusable method. This process enables public health systems to generate and transmit essential information quickly while reducing the time and effort needed to respond to data requests in proprietary and custom formats.",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/ph-bulk-data/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/ph-bulk-data",
-    "ci-build" : "http://build.fhir.org/ig/HL7/us-helios-bulk/en/index.html",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "Informative 2 Ballot",
-      "ig-version" : "2.0.0-ballot",
-      "package" : "hl7.fhir.us.ph-bulk-data#2.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/ph-bulk-data/2026May"
-    }]
-  },
-  {
-    "name" : "US Patient Care Summary (US-PCS) Implementation Guide",
-    "category" : "Patient Summary",
-    "npm-name" : "hl7.fhir.us.pcs",
-    "description" : "The United States Patient Care Summary (US-PCS) is a FHIR document that captures key information for care transitions. It aligns with work from the FHIR International Patient Summary and is intended as a modern, streamlined summary that builds on the long-standing exchange of clinical documents in the United States using the Consolidated Clinical Document Architecture (C-CDA) and specifically the Continuity of Care Document (CCD).",
-    "authority" : "HL7",
-    "country" : "us",
-    "history" : "http://hl7.org/fhir/us/pcs/history.html",
-    "language" : ["en"],
-    "canonical" : "http://hl7.org/fhir/us/pcs",
-    "ci-build" : "http://build.fhir.org/ig/HL7/us-fhir-ps",
-    "product" : ["fhir"],
-    "editions" : [{
-      "name" : "STU 1 Ballot",
-      "ig-version" : "1.0.0-ballot",
-      "package" : "hl7.fhir.us.pcs#1.0.0-ballot",
-      "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.org/fhir/us/pcs/2026May"
-    }]
-  }]
+  ]
 }

--- a/package-feeds.json
+++ b/package-feeds.json
@@ -1,15 +1,235 @@
 {
-  "comment" : "The order of the feeds does not matter, but the order of the package-restrictions does",
-  "servers" : {
-    "comment" : "This is the known publicly available servers that crawl this package list and make a conformant packages API available",
-    "https://packages.fhir.org" : "Official Package registry (hosted on simplifier.net)",
-    "https://packages2.fhir.org/packages" : "Alternative. Has more packages because it hosts packages associated with non-official releases of FHIR"
+  "comment": "The order of the feeds does not matter, but the order of the package-restrictions does",
+  "servers": {
+    "comment": "This is the known publicly available servers that crawl this package list and make a conformant packages API available",
+    "https://packages.fhir.org": "Official Package registry (hosted on simplifier.net)",
+    "https://packages2.fhir.org/packages": "Alternative. Has more packages because it hosts packages associated with non-official releases of FHIR"
   },
   "feeds": [
     {
-      "name": "HL7.org FHIR Publications",
-      "url": "http://hl7.org/fhir/package-feed.xml",
+      "name": "Agence du Num\u00e9rique en Sant\u00e9",
+      "url": "https://interop.esante.gouv.fr/package-feed.xml",
+      "errors": "mael_priour|esante_gouv_fr"
+    },
+    {
+      "name": "Agence du Num\u00e9rique en Sant\u00e9",
+      "url": "https://interop.esante.gouv.fr/ig/package-feed.xml",
+      "errors": "nicolas_riss|esante_gouv_fr"
+    },
+    {
+      "name": "Agence du Num\u00e9rique en Sant\u00e9 - CDA IG",
+      "url": "https://interop.esante.gouv.fr/ig/cda/package-feed.xml",
+      "errors": "nicolas_riss|esante_gouv_fr"
+    },
+    {
+      "name": "Agence du Num\u00e9rique en Sant\u00e9 - Document IG",
+      "url": "https://interop.esante.gouv.fr/ig/document/package-feed.xml",
+      "errors": "nicolas_riss|esante_gouv_fr"
+    },
+    {
+      "name": "Agence du Num\u00e9rique en Sant\u00e9 - FHIR IG",
+      "url": "https://interop.esante.gouv.fr/ig/fhir/package-feed.xml",
+      "errors": "nicolas_riss|esante_gouv_fr"
+    },
+    {
+      "name": "Annotate MD",
+      "url": "https://annotatemd.com/fhir/package-feed.xml",
+      "errors": "fhir@annotatemd.com"
+    },
+    {
+      "name": "Argentix Informatics FHIR Implementation Guides",
+      "url": "http://argentixinfo.com/ig/package-feed.xml",
+      "errors": "elliot|argentixinfo_com"
+    },
+    {
+      "name": "BfArM FHIR Packages (Terminologies)",
+      "url": "https://terminologien.bfarm.de/feeds?publishToHl7=true",
+      "errors": "zts|gematik_de"
+    },
+    {
+      "name": "CDS-Hooks",
+      "url": "https://cds-hooks.hl7.org/package-feed.xml",
       "errors": "grahame|fhir_org"
+    },
+    {
+      "name": "CGIS (UFG) Brasil",
+      "url": "https://fhir.fabrica.inf.ufg.br/package-feed.xml",
+      "errors": "kyriosdata|ufg_br"
+    },
+    {
+      "name": "Clic Sante",
+      "url": "http://documentation.clicsante.ca/fhir/package-feed.xml",
+      "errors": "aachik|trimoz_com"
+    },
+    {
+      "name": "Common FHIR profile vendor collaboration",
+      "url": "https://commonprofiles.care/package-feed.xml",
+      "errors": "info|commonprofiles.care"
+    },
+    {
+      "name": "Common HL7 Terminology",
+      "url": "http://terminology.hl7.org/package-feed.xml",
+      "errors": "utg|hl7_org"
+    },
+    {
+      "name": "CSIRO FHIR Implementation Guides",
+      "url": "https://starsapi.csiro.au/fhir-ig/package-feed.xml",
+      "errors": "stars-support|csiro_au"
+    },
+    {
+      "name": "Danish FUT Infrastructure",
+      "url": "https://ehealth.sundhed.dk/package-feed.xml",
+      "errors": "jvi|trifork_com"
+    },
+    {
+      "name": "DGHS Bangladesh",
+      "url": "https://fhir.dghs.gov.bd/core/package-feed.xml",
+      "errors": "digitalhealth|dghs_gov_bd"
+    },
+    {
+      "name": "DHP & UZ Core Uzbekistan Packages",
+      "url": "https://raw.githubusercontent.com/uzinfocom-org/digital-health-ig/refs/heads/main/docs/package-feed.xml",
+      "errors": "fhir|vadimperetok.in"
+    },
+    {
+      "name": "Estonian FHIR Publications",
+      "url": "https://fhir.ee/packages/package-feed.xml",
+      "errors": "fhir|kodality_com"
+    },
+    {
+      "name": "FHIR Foundation Guides",
+      "url": "http://fhir.org/guides/package-feed.xml",
+      "errors": "grahame|fhir_org"
+    },
+    {
+      "name": "FHIR Foundation Publishing Templates",
+      "url": "http://fhir.org/templates/package-feed.xml",
+      "errors": "grahame|fhir_org"
+    },
+    {
+      "name": "FHIR Foundation Support Packages",
+      "url": "http://fhir.org/packages/package-feed.xml",
+      "errors": "grahame|fhir_org"
+    },
+    {
+      "name": "FHIR Implementation Guide for Ayushman Bharat Digital Mission",
+      "url": "https://nrces.in/ndhm/package-feed.xml",
+      "errors": "ABDM|NRCeS"
+    },
+    {
+      "name": "gematik FHIR Packages",
+      "url": "https://gemspec.gematik.de/ig/fhir/package-feed.xml",
+      "errors": "patientteam|gematik_de"
+    },
+    {
+      "name": "GKL",
+      "url": "https://gabriel0316.github.io/ig-tooling-pages/package-feed.xml",
+      "errors": "gabriel_kleinoscheg|elga_gv_at"
+    },
+    {
+      "name": "Health New Zealand Te Whatu Ora FHIR Implementation Guides",
+      "url": "https://fhir-ig.digital.health.nz/package-feed.xml",
+      "errors": "integration|tewhatuora_govt_nz"
+    },
+    {
+      "name": "Health Samurai FHIR Implementation Guides",
+      "url": "https://storage.googleapis.com/health-samurai-igs/fhir-feed.xml",
+      "errors": "hello|health-samurai_io"
+    },
+    {
+      "name": "HL7 Australia",
+      "url": "http://hl7.org.au/fhir/package-feed.xml",
+      "errors": "brett_esler|oridashi_com_au "
+    },
+    {
+      "name": "HL7 Austria",
+      "url": "https://fhir.hl7.at/package-feed.xml",
+      "errors": "tc-fhir|hl7_at"
+    },
+    {
+      "name": "HL7 Belgium/eHealth Platform",
+      "url": "https://www.ehealth.fgov.be/standards/fhir/package-feed.xml",
+      "errors": "message-structure|ehealth_fgov_be"
+    },
+    {
+      "name": "HL7 Chile",
+      "url": "https://hl7chile.cl/fhir/ig/package-feed.xml",
+      "errors": "jorge_mansilla|hl7chile_cl"
+    },
+    {
+      "name": "HL7 Chile IPS",
+      "url": "https://hl7chile.cl/fhir/ig/clips/package-feed.xml",
+      "errors": "Franco_Ulloa|hl7chile_clips_cl"
+    },
+    {
+      "name": "HL7 Czech Republic FHIR Implementation Guides",
+      "url": "https://hl7.cz/fhir/package-feed.xml",
+      "errors": "kruzik|hl7_cz"
+    },
+    {
+      "name": "HL7 Czech Republic Terminology",
+      "url": "https://hl7.cz/terminology/package-feed.xml",
+      "errors": "kruzik|hl7_cz"
+    },
+    {
+      "name": "HL7 Denmark",
+      "url": "https://hl7.dk/fhir/package-feed.xml",
+      "errors": "jvi|trifork_com"
+    },
+    {
+      "name": "HL7 Europe",
+      "url": "http://hl7.eu/fhir/package-feed.xml",
+      "errors": "gcangioli|hl7_eu"
+    },
+    {
+      "name": "HL7 FHIR Costa Rica Terminolog\u00eda",
+      "url": "https://hl7.or.cr/fhir/terminology/package-feed.xml",
+      "errors": "info|hl7_or_cr"
+    },
+    {
+      "name": "HL7 Finland",
+      "url": "https://hl7.fi/fhir/package-feed.xml",
+      "errors": "mikael|sensotrend_com"
+    },
+    {
+      "name": "HL7 France",
+      "url": "https://hl7.fr/ig/fhir/package-feed.xml",
+      "errors": "nicolas_riss|esante_gouv_fr"
+    },
+    {
+      "name": "HL7 Germany",
+      "url": "https://ig.fhir.de/igs/package-feed.xml",
+      "errors": "cto|hl7_de"
+    },
+    {
+      "name": "HL7 Korea FHIR Implementation Guides",
+      "url": "https://www.hl7korea.or.kr/fhir/package-feed.xml",
+      "errors": "hl7korea|gmail_com"
+    },
+    {
+      "name": "HL7 Lithuania FHIR Implementation Guides",
+      "url": "https://hl7.lt/packages/package-feed.xml",
+      "errors": "info|medicinosnk_lt"
+    },
+    {
+      "name": "HL7 New Zealand",
+      "url": "https://github.com/HL7NZ/hl7-nz-package-feed/blob/main/package-feed.xml?raw=true",
+      "errors": "admin|hl7_org_nz"
+    },
+    {
+      "name": "HL7 Poland",
+      "url": "http://fhir.hl7.org.pl/packages/package-feed.xml",
+      "errors": "bojanowski|hl7.org.pl"
+    },
+    {
+      "name": "HL7 Sweden",
+      "url": "https://hl7.se/fhir/ig/package-feed.xml",
+      "errors": "petur_valdimarsson|chorus_se"
+    },
+    {
+      "name": "HL7 Switzerland",
+      "url": "http://fhir.ch/package-feed.xml",
+      "errors": "oliver_egger|ahdis_ch"
     },
     {
       "name": "HL7.org CDA Publications",
@@ -22,199 +242,14 @@
       "errors": "grahame|fhir_org"
     },
     {
-      "name": "Common HL7 Terminology",
-      "url": "http://terminology.hl7.org/package-feed.xml",
-      "errors": "utg|hl7_org"
-    },
-    {
-      "name": "CDS-Hooks",
-      "url": "https://cds-hooks.hl7.org/package-feed.xml",
+      "name": "HL7.org FHIR Publications",
+      "url": "http://hl7.org/fhir/package-feed.xml",
       "errors": "grahame|fhir_org"
-    },
-    {
-      "name": "FHIR Foundation Guides",
-      "url": "http://fhir.org/guides/package-feed.xml",
-      "errors": "grahame|fhir_org"
-    },
-    {
-      "name": "FHIR Foundation Support Packages",
-      "url": "http://fhir.org/packages/package-feed.xml",
-      "errors": "grahame|fhir_org"
-    },
-    {
-      "name": "FHIR Foundation Publishing Templates",
-      "url": "http://fhir.org/templates/package-feed.xml",
-      "errors": "grahame|fhir_org"
-    },
-    {
-      "name": "HL7 Australia",
-      "url": "http://hl7.org.au/fhir/package-feed.xml",
-      "errors": "brett_esler|oridashi_com_au "
-    },
-    {
-      "name": "HL7 Switzerland",
-      "url": "http://fhir.ch/package-feed.xml",
-      "errors": "oliver_egger|ahdis_ch"
-    },
-    {
-      "name": "HL7 France",
-      "url": "https://hl7.fr/ig/fhir/package-feed.xml",
-      "errors": "nicolas_riss|esante_gouv_fr"
-    },
-    {
-      "name": "Agence du Numérique en Santé",
-      "url": "https://interop.esante.gouv.fr/package-feed.xml",
-      "errors": "mael_priour|esante_gouv_fr"
-    },
-    {
-      "name": "Agence du Numérique en Santé",
-      "url": "https://interop.esante.gouv.fr/ig/package-feed.xml",
-      "errors": "nicolas_riss|esante_gouv_fr"
-    },
-    {
-      "name": "Agence du Numérique en Santé - FHIR IG",
-      "url": "https://interop.esante.gouv.fr/ig/fhir/package-feed.xml",
-      "errors": "nicolas_riss|esante_gouv_fr"
-    }, 
-    {
-      "name": "Agence du Numérique en Santé - CDA IG",
-      "url": "https://interop.esante.gouv.fr/ig/cda/package-feed.xml",
-      "errors": "nicolas_riss|esante_gouv_fr"
-    }, 
-	{
-      "name": "Agence du Numérique en Santé - Document IG",
-      "url": "https://interop.esante.gouv.fr/ig/document/package-feed.xml",
-      "errors": "nicolas_riss|esante_gouv_fr"
-    }, 
-    { 
-        "name": "HL7 Denmark", 
-        "url": "https://hl7.dk/fhir/package-feed.xml", 
-        "errors": "jvi|trifork_com" 
-    }, 
-    { 
-        "name": "Kommunernes Landsforening (KL)", 
-        "url": "https://fhir.kl.dk/package-feed.xml", 
-        "errors": "jvi|trifork_com" 
-    },
-    {
-        "name": "Danish FUT Infrastructure",
-        "url": "https://ehealth.sundhed.dk/package-feed.xml",
-        "errors": "jvi|trifork_com"
-    },
-    {
-      "name": "mednet.swiss",
-      "url": "https://doc.mednet.swiss/fhir/package-feed.xml",
-      "errors": "david_gutknecht|novcom_swiss"
-    },
-    {
-      "name": "HL7 New Zealand",
-      "url": "https://github.com/HL7NZ/hl7-nz-package-feed/blob/main/package-feed.xml?raw=true",
-      "errors": "admin|hl7_org_nz"
     },
     {
       "name": "IHE International",
       "url": "https://profiles.ihe.net/fhir/package-feed.xml",
       "errors": "secretary|ihe_net"
-    },
-    {
-      "name": "HL7 Belgium/eHealth Platform",
-      "url": "https://www.ehealth.fgov.be/standards/fhir/package-feed.xml",
-      "errors": "message-structure|ehealth_fgov_be"
-    },
-    {
-      "name": "HL7 Germany",
-      "url": "https://ig.fhir.de/igs/package-feed.xml",
-      "errors": "cto|hl7_de"
-    },
-    {
-      "name": "Estonian FHIR Publications",
-      "url": "https://fhir.ee/packages/package-feed.xml",
-      "errors": "fhir|kodality_com"
-    },
-    {
-      "name": "HL7 Sweden",
-      "url": "https://hl7.se/fhir/ig/package-feed.xml",
-      "errors": "petur_valdimarsson|chorus_se"
-    },
-    {
-      "name": "HL7 Chile",
-      "url": "https://hl7chile.cl/fhir/ig/package-feed.xml",
-      "errors": "jorge_mansilla|hl7chile_cl"
-    },
-    {
-      "name": "Thailand SIL-TH",
-      "url": "https://fhir-ig.sil-th.org/package-feed.xml",
-      "errors": "rath|sil-th_org"
-    },
-    {
-      "name": "Thailand SIL-TH Terminology",
-      "url": "https://terms.sil-th.org/package-feed.xml",
-      "errors": "rath|sil-th_org"
-    },
-    {
-      "name": "CGIS (UFG) Brasil",
-      "url": "https://fhir.fabrica.inf.ufg.br/package-feed.xml",
-      "errors": "kyriosdata|ufg_br"
-    },
-    {
-      "name": "Secretaria de Estado da Saúde de Goiás | Brasil",
-      "url": "https://fhir.saude.go.gov.br/package-feed.xml",
-      "errors": "ses_go|goias_gov_br"
-    },
-    {
-      "name": "MedCom",
-      "url": "https://medcomfhir.dk/ig/package-feed.xml",
-      "errors": "tms|medcom_dk"
-    },
-    {
-      "name": "MedCom EHMI",
-      "url": "https://medcomehmi.dk/ig/package-feed.xml",
-      "errors": "olw|medcom_dk"
-    },
-    {
-      "name": "Common FHIR profile vendor collaboration",
-      "url": "https://commonprofiles.care/package-feed.xml",
-      "errors": "info|commonprofiles.care"
-    },
-    {
-      "name": "HL7 Europe",
-      "url": "http://hl7.eu/fhir/package-feed.xml",
-      "errors": "gcangioli|hl7_eu"
-    },
-    {
-      "name": "Simplifier",
-      "url": "https://packages.simplifier.net/rssfeed",
-      "errors": "simplifier|fire_ly"
-    },
-    {
-      "name": "HL7 Finland",
-      "url": "https://hl7.fi/fhir/package-feed.xml",
-      "errors": "mikael|sensotrend_com"
-    },
-    {
-      "name": "University Medicine Greifswald - Department of Anesthesia, Intensive Care, Emergency and Pain Medicine",
-      "url": "https://github.com/umg-minai/fhir-package-feed/blob/main/package-feed.xml?raw=true",
-      "errors": "gregor_lichtner|med_uni-greifswald_de"
-    },
-    {
-      "name": "HL7 Austria",
-      "url": "https://fhir.hl7.at/package-feed.xml",
-      "errors": "tc-fhir|hl7_at"
-    },
-    {
-      "name": "GKL",
-      "url": "https://gabriel0316.github.io/ig-tooling-pages/package-feed.xml",
-      "errors": "gabriel_kleinoscheg|elga_gv_at"
-    },
-    {
-      "name": "FHIR Implementation Guide for Ayushman Bharat Digital Mission",
-      "url": "https://nrces.in/ndhm/package-feed.xml",
-      "errors": "ABDM|NRCeS"
-    },
-    {
-      "name": "RIVO-Noord NL",
-      "url": "http://implementatiegids.zorgviewer.nl/package-feed.xml",
-      "errors": "m_van_der_zel|umcg_nl"
     },
     {
       "name": "IKNL",
@@ -227,59 +262,74 @@
       "errors": "fhir|iknl_nl"
     },
     {
-      "name": "Health New Zealand Te Whatu Ora FHIR Implementation Guides",
-      "url": "https://fhir-ig.digital.health.nz/package-feed.xml",
-      "errors": "integration|tewhatuora_govt_nz"
+      "name": "Kommunernes Landsforening (KL)",
+      "url": "https://fhir.kl.dk/package-feed.xml",
+      "errors": "jvi|trifork_com"
     },
     {
-      "name": "World Health Organization",
-      "url": "https://smart.who.int/package-feed.xml",
-      "errors": "smart|who_int"
+      "name": "MedCom",
+      "url": "https://medcomfhir.dk/ig/package-feed.xml",
+      "errors": "tms|medcom_dk"
     },
     {
-      "name": "Argentix Informatics FHIR Implementation Guides",
-      "url": "http://argentixinfo.com/ig/package-feed.xml",
-      "errors": "elliot|argentixinfo_com"
+      "name": "MedCom EHMI",
+      "url": "https://medcomehmi.dk/ig/package-feed.xml",
+      "errors": "olw|medcom_dk"
     },
     {
-      "name": "HL7 Chile IPS",
-      "url": "https://hl7chile.cl/fhir/ig/clips/package-feed.xml",
-      "errors": "Franco_Ulloa|hl7chile_clips_cl"
+      "name": "mednet.swiss",
+      "url": "https://doc.mednet.swiss/fhir/package-feed.xml",
+      "errors": "david_gutknecht|novcom_swiss"
     },
     {
       "name": "MINSAL CHILE EIS",
       "url": "https://interoperabilidad.minsal.cl/fhir/ig/eis/package-feed.xml",
       "errors": "Jorge_Mansilla|MINSAL_EIS"
-    } ,
+    },
     {
       "name": "MINSAL CHILE NID",
       "url": "https://interoperabilidad.minsal.cl/fhir/ig/nid/package-feed.xml",
       "errors": "Jorge_Mansilla|MINSAL_NID"
     },
     {
-      "name": "Clic Sante",
-      "url": "http://documentation.clicsante.ca/fhir/package-feed.xml",
-      "errors": "aachik|trimoz_com"
-    },
-    {
-      "name": "BfArM FHIR Packages (Terminologies)",
-      "url": "https://terminologien.bfarm.de/feeds?publishToHl7=true",
-      "errors": "zts|gematik_de"
-    },
-    {
-      "name": "gematik FHIR Packages",
-      "url": "https://gemspec.gematik.de/ig/fhir/package-feed.xml",
-      "errors": "patientteam|gematik_de"
-    },
-    {
-      "name": "HL7 Poland",
-      "url": "http://fhir.hl7.org.pl/packages/package-feed.xml",
-      "errors": "bojanowski|hl7.org.pl"
-    },
-    {
       "name": "MyHealth@eu",
       "url": "https://fhir.ehdsi.eu/package-feed.xml",
       "errors": "gcangioli|ehdsi_eu"
+    },
+    {
+      "name": "ONCOFAIR IGs",
+      "url": "https://oncofair-ig.kereval.cloud/package-feed.xml",
+      "errors": "alain_ribault|kereval_com"
+    },
+    {
+      "name": "RIVO-Noord NL",
+      "url": "http://implementatiegids.zorgviewer.nl/package-feed.xml",
+      "errors": "m_van_der_zel|umcg_nl"
+    },
+    {
+      "name": "Secretaria de Estado da Sa\u00fade de Goi\u00e1s | Brasil",
+      "url": "https://fhir.saude.go.gov.br/package-feed.xml",
+      "errors": "ses_go|goias_gov_br"
+    },
+    {
+      "name": "Service Well FHIR Liquid Converter Implementation Guides",
+      "url": "https://canonical.fhir.link/flc/package-feed.xml",
+      "errors": "support|servicewell_se"
+    },
+    {
+      "name": "Service Well Implementation Guides",
+      "url": "https://canonical.fhir.link/servicewell/package-feed.xml",
+      "errors": "support|servicewell_se"
+    },
+    {
+      "name": "Simplifier",
+      "url": "https://packages.simplifier.net/rssfeed",
+      "errors": "simplifier|fire_ly"
+    },
+    {
+      "name": "SQL on FHIR",
+      "url": "https://sql-on-fhir.org/ig/package-feed.xml",
+      "errors": "pathling|csiro_au"
     },
     {
       "name": "Taiwan FHIR Packages",
@@ -291,238 +341,287 @@
       "url": "https://nhicore.nhi.gov.tw/packages/package-feed.xml",
       "errors": "TWNHI_FHIR|nhi_gov_tw"
     },
-	  {
-      "name": "DHP & UZ Core Uzbekistan Packages",
-      "url": "https://raw.githubusercontent.com/uzinfocom-org/digital-health-ig/refs/heads/main/docs/package-feed.xml",
-      "errors": "fhir|vadimperetok.in"
+    {
+      "name": "Thailand SIL-TH",
+      "url": "https://fhir-ig.sil-th.org/package-feed.xml",
+      "errors": "rath|sil-th_org"
     },
     {
-      "name": "CSIRO FHIR Implementation Guides",
-      "url": "https://starsapi.csiro.au/fhir-ig/package-feed.xml",
-      "errors": "stars-support|csiro_au"
-    },
-	  {
-      "name": "DGHS Bangladesh",
-      "url": "https://fhir.dghs.gov.bd/core/package-feed.xml",
-      "errors": "digitalhealth|dghs_gov_bd"
+      "name": "Thailand SIL-TH Terminology",
+      "url": "https://terms.sil-th.org/package-feed.xml",
+      "errors": "rath|sil-th_org"
     },
     {
-      "name": "HL7 Lithuania FHIR Implementation Guides",
-      "url": "https://hl7.lt/packages/package-feed.xml",
-      "errors": "info|medicinosnk_lt"
+      "name": "University Medicine Greifswald - Department of Anesthesia, Intensive Care, Emergency and Pain Medicine",
+      "url": "https://github.com/umg-minai/fhir-package-feed/blob/main/package-feed.xml?raw=true",
+      "errors": "gregor_lichtner|med_uni-greifswald_de"
     },
     {
-      "name": "Service Well FHIR Liquid Converter Implementation Guides",
-      "url": "https://canonical.fhir.link/flc/package-feed.xml",
-      "errors": "support|servicewell_se"
-    },
-    {
-      "name":"ONCOFAIR IGs",
-      "url":"https://oncofair-ig.kereval.cloud/package-feed.xml",
-      "errors":"alain_ribault|kereval_com"
-    },
-    {
-      "name": "HL7 FHIR Costa Rica Terminología",
-      "url": "https://hl7.or.cr/fhir/terminology/package-feed.xml",
-      "errors": "info|hl7_or_cr"
-    },
-    {
-      "name": "Service Well Implementation Guides",
-      "url": "https://canonical.fhir.link/servicewell/package-feed.xml",
-      "errors": "support|servicewell_se"
-    },
-  	{
-      "name": "HL7 Korea FHIR Implementation Guides",
-      "url": "https://www.hl7korea.or.kr/fhir/package-feed.xml",
-      "errors": "hl7korea|gmail_com"
-	  },
-    {
-      "name": "SQL on FHIR",
-      "url": "https://sql-on-fhir.org/ig/package-feed.xml",
-      "errors": "pathling|csiro_au"
-    },
-    {
-      "name": "Health Samurai FHIR Implementation Guides",
-      "url": "https://storage.googleapis.com/health-samurai-igs/fhir-feed.xml",
-      "errors": "hello|health-samurai_io"
-    },
-    {
-      "name": "HL7 Czech Republic Terminology",
-      "url": "https://hl7.cz/terminology/package-feed.xml",
-      "errors": "kruzik|hl7_cz"
-    },
-    {
-      "name": "HL7 Czech Republic FHIR Implementation Guides",
-      "url": "https://hl7.cz/fhir/package-feed.xml",
-      "errors": "kruzik|hl7_cz"
+      "name": "World Health Organization",
+      "url": "https://smart.who.int/package-feed.xml",
+      "errors": "smart|who_int"
     }
   ],
   "package-restrictions": [
-	{
+    {
       "mask": "hl7.fhir.be.*",
-      "feeds": [ "https://www.ehealth.fgov.be/standards/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://www.ehealth.fgov.be/standards/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.au.*",
-      "feeds": [ "http://hl7.org.au/fhir/package-feed.xml" ]
+      "feeds": [
+        "http://hl7.org.au/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "fhir.org.nz.ig.*",
-      "feeds": [ "https://github.com/HL7NZ/hl7-nz-package-feed/blob/main/package-feed.xml?raw=true" ]
+      "feeds": [
+        "https://github.com/HL7NZ/hl7-nz-package-feed/blob/main/package-feed.xml?raw=true"
+      ]
     },
     {
-        "mask": "hl7.fhir.dk.*",
-        "feeds": [ "https://hl7.dk/fhir/package-feed.xml" ]
+      "mask": "hl7.fhir.dk.*",
+      "feeds": [
+        "https://hl7.dk/fhir/package-feed.xml"
+      ]
     },
     {
-        "mask": "kl.dk.fhir.*",
-        "feeds": [ "https://fhir.kl.dk/package-feed.xml" ]
+      "mask": "kl.dk.fhir.*",
+      "feeds": [
+        "https://fhir.kl.dk/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.ee.*",
-      "feeds": [ "https://fhir.ee/packages/package-feed.xml"  ]
+      "feeds": [
+        "https://fhir.ee/packages/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.kr.*",
-      "feeds": [ "https://www.hl7korea.or.kr/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://www.hl7korea.or.kr/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.eu.*",
-      "feeds": [ "https://hl7.eu/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://hl7.eu/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.fr.*",
-      "feeds": [ "https://hl7.fr/ig/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://hl7.fr/ig/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.nl.*",
-      "feeds": [ "https://implementatiegids.zorgviewer.nl/package-feed.xml", "https://packages.simplifier.net/rssfeed" ]
+      "feeds": [
+        "https://implementatiegids.zorgviewer.nl/package-feed.xml",
+        "https://packages.simplifier.net/rssfeed"
+      ]
     },
     {
       "mask": "hl7.fhir.fi.*",
-      "feeds": [ "https://hl7.fi/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://hl7.fi/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.cl.*",
-      "feeds": [ "https://hl7chile.cl/fhir/ig/package-feed.xml", "https://fhir.org/guides/package-feed.xml" ]
+      "feeds": [
+        "https://hl7chile.cl/fhir/ig/package-feed.xml",
+        "https://fhir.org/guides/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.*",
-      "feeds": [ "http://hl7.org/fhir/package-feed.xml", "http://fhir.org/packages/package-feed.xml", "http://fhir.org/guides/package-feed.xml", "http://fhir.org/templates/package-feed.xml",
-	         "https://hl7.org/fhir/package-feed.xml", "https://fhir.org/packages/package-feed.xml", "https://fhir.org/guides/package-feed.xml", "https://fhir.org/templates/package-feed.xml"]
+      "feeds": [
+        "http://hl7.org/fhir/package-feed.xml",
+        "http://fhir.org/packages/package-feed.xml",
+        "http://fhir.org/guides/package-feed.xml",
+        "http://fhir.org/templates/package-feed.xml",
+        "https://hl7.org/fhir/package-feed.xml",
+        "https://fhir.org/packages/package-feed.xml",
+        "https://fhir.org/guides/package-feed.xml",
+        "https://fhir.org/templates/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.cda.*",
-      "feeds": [ "http://hl7.org/cda/stds/package-feed.xml", "http://fhir.org/templates/package-feed.xml"]
+      "feeds": [
+        "http://hl7.org/cda/stds/package-feed.xml",
+        "http://fhir.org/templates/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.xprod.*",
-      "feeds": [ "http://hl7.org/xprod/ig/package-feed.xml" ]
+      "feeds": [
+        "http://hl7.org/xprod/ig/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.tx.*",
-      "feeds": [ "http://terminology.hl7.org/package-feed.xml" ]
+      "feeds": [
+        "http://terminology.hl7.org/package-feed.xml"
+      ]
     },
     {
       "mask": "fhir.*",
-      "feeds": [ "http://fhir.org/packages/package-feed.xml", "http://fhir.org/templates/package-feed.xml", "http://fhir.org/guides/package-feed.xml" ]
+      "feeds": [
+        "http://fhir.org/packages/package-feed.xml",
+        "http://fhir.org/templates/package-feed.xml",
+        "http://fhir.org/guides/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.au.fhir.*",
-      "feeds": [ "http://hl7.org.au/fhir/package-feed.xml", "http://fhir.org/templates/package-feed.xml"
+      "feeds": [
+        "http://hl7.org.au/fhir/package-feed.xml",
+        "http://fhir.org/templates/package-feed.xml"
       ]
     },
     {
       "mask": "ch.fhir.ig.*",
-      "feeds": [ "http://fhir.ch/package-feed.xml" ]
+      "feeds": [
+        "http://fhir.ch/package-feed.xml"
+      ]
     },
     {
       "mask": "ans.fr.template*",
-      "feeds": [ "https://fhir.org/templates/package-feed.xml" ]
+      "feeds": [
+        "https://fhir.org/templates/package-feed.xml"
+      ]
     },
-	{
+    {
       "mask": "ans.fr.document.*",
-      "feeds": [ "https://interop.esante.gouv.fr/ig/document/package-feed.xml" ]
+      "feeds": [
+        "https://interop.esante.gouv.fr/ig/document/package-feed.xml"
+      ]
     },
     {
       "mask": "ans.fr.*",
-      "feeds": [ "https://interop.esante.gouv.fr/ig/package-feed.xml", "https://interop.esante.gouv.fr/package-feed.xml" ]
+      "feeds": [
+        "https://interop.esante.gouv.fr/ig/package-feed.xml",
+        "https://interop.esante.gouv.fr/package-feed.xml"
+      ]
     },
     {
       "mask": "ans.fhir.fr.*",
-      "feeds": [ "https://interop.esante.gouv.fr/ig/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://interop.esante.gouv.fr/ig/fhir/package-feed.xml"
+      ]
     },
-  	{
+    {
       "mask": "ans.cda.fr.*",
-      "feeds": [ "https://interop.esante.gouv.fr/ig/cda/package-feed.xml" ]
+      "feeds": [
+        "https://interop.esante.gouv.fr/ig/cda/package-feed.xml"
+      ]
     },
     {
       "mask": "ihe.*",
-      "feeds": [ "http://profiles.ihe.net/fhir/package-feed.xml", "http://fhir.org/templates/package-feed.xml"  ]
+      "feeds": [
+        "http://profiles.ihe.net/fhir/package-feed.xml",
+        "http://fhir.org/templates/package-feed.xml"
+      ]
     },
     {
       "mask": "silth.fhir.*",
-      "feeds": [ "https://fhir-ig.sil-th.org/package-feed.xml", "https://terms.sil-th.org/package-feed.xml" ]
+      "feeds": [
+        "https://fhir-ig.sil-th.org/package-feed.xml",
+        "https://terms.sil-th.org/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.it.*",
-      "feeds": [ "http://hl7.it/fhir/package-feed.xml" ]
+      "feeds": [
+        "http://hl7.it/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.at.fhir.gkl.*",
-      "feeds": [ "https://gabriel0316.github.io/ig-tooling-pages/package-feed.xml" ]
+      "feeds": [
+        "https://gabriel0316.github.io/ig-tooling-pages/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.at.fhir.template*",
-      "feeds": [ "https://fhir.org/templates/package-feed.xml" ]
+      "feeds": [
+        "https://fhir.org/templates/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.at.fhir.*",
-      "feeds": [ "https://fhir.hl7.at/package-feed.xml" ]
+      "feeds": [
+        "https://fhir.hl7.at/package-feed.xml"
+      ]
     },
     {
       "mask": "dk.ehealth.sundhed.fhir.ig.*",
-      "feeds": [ "https://ehealth.sundhed.dk/package-feed.xml" ]
+      "feeds": [
+        "https://ehealth.sundhed.dk/package-feed.xml"
+      ]
     },
     {
       "mask": "bfarm.terminologien.*",
-      "feeds": [ "https://terminologien.bfarm.de/feeds?publishToHl7=true" ]
+      "feeds": [
+        "https://terminologien.bfarm.de/feeds?publishToHl7=true"
+      ]
     },
     {
       "mask": "hl7.fhir.pl.*",
-      "feeds": [ "https://fhir.hl7.org.pl/packages/package-feed.xml" ]
+      "feeds": [
+        "https://fhir.hl7.org.pl/packages/package-feed.xml"
+      ]
     },
     {
       "mask": "myhealth.eu.fhir.*",
-      "feeds": [ "https://fhir.ehdsi.eu/package-feed.xml" ]
+      "feeds": [
+        "https://fhir.ehdsi.eu/package-feed.xml"
+      ]
     },
     {
       "mask": "tw.gov.mohw.*",
-      "feeds": [ "https://twcore.mohw.gov.tw/ig/packages/package-feed.xml", "https://nhicore.nhi.gov.tw/packages/package-feed.xml" ]
+      "feeds": [
+        "https://twcore.mohw.gov.tw/ig/packages/package-feed.xml",
+        "https://nhicore.nhi.gov.tw/packages/package-feed.xml"
+      ]
     },
     {
       "mask": "lt.hl7.fhir.*",
-      "feeds": [ "https://hl7.lt/packages/package-feed.xml", "https://hl7.lt/ig/package-feed.xml" ]
+      "feeds": [
+        "https://hl7.lt/packages/package-feed.xml",
+        "https://hl7.lt/ig/package-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.cr.*",
-      "feeds": [ "https://hl7.or.cr/fhir/terminology/package-feed.xml", "https://fhir.org/guides/package-feed.xml" ]
+      "feeds": [
+        "https://hl7.or.cr/fhir/terminology/package-feed.xml",
+        "https://fhir.org/guides/package-feed.xml"
+      ]
     },
     {
       "mask": "io.health-samurai.*",
-      "feeds": [ "https://storage.googleapis.com/health-samurai-igs/fhir-feed.xml" ]
+      "feeds": [
+        "https://storage.googleapis.com/health-samurai-igs/fhir-feed.xml"
+      ]
     },
     {
       "mask": "hl7.fhir.cz.*",
-      "feeds": [ "https://hl7.cz/terminology/package-feed.xml", "https://hl7.cz/fhir/package-feed.xml" ]
+      "feeds": [
+        "https://hl7.cz/terminology/package-feed.xml",
+        "https://hl7.cz/fhir/package-feed.xml"
+      ]
     },
     {
       "mask": "xtehr.eu.ehds.*",
-      "feeds": [ "http://www.xt-ehr.eu/fhir/package-feed.xml" ]
+      "feeds": [
+        "http://www.xt-ehr.eu/fhir/package-feed.xml"
+      ]
     }
   ]
-
 }
-
-
-


### PR DESCRIPTION
Registering the Annotate MD Dermatology Image Annotation IG (annotatemd.dermatology-annotation v0.1.0).

- **Canonical:** https://annotatemd.com/fhir/ig
- **CI build:** https://build.fhir.org/ig/s25rawlins/annotate-md/
- **Package feed:** https://annotatemd.com/fhir/package-feed.xml
- **FHIR version:** R4 (4.0.1)

This is the first FHIR IG for structured dermatology image annotation, with profiles for annotation results, AI predictions with transparency metadata, and temporal lesion tracking.