### PR TITLE
Add HEARTLAND Protocol FHIR Implementation Guide

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -9858,5 +9858,25 @@
       "fhir-version" : ["4.0.1"],
       "url" : "http://hl7.org/fhir/us/darts/2026May"
     }]
+  },
+  {
+    "name" : "HEARTLAND Protocol FHIR Implementation Guide",
+    "category" : "Quality / CDS",
+    "npm-name" : "heartland.fhir.us.protocol",
+    "description" : "FHIR R4 Implementation Guide for the HEARTLAND Protocol — an open, peer-reviewed clinical implementation toolkit for primary-care-led heart failure management in rural and resource-limited US settings (Cureus 2026, PMID 41948265). Defines profiles, extensions, questionnaires, and value sets for risk stratification, facility tier assignment, patient track assignment, and remote monitoring observations.",
+    "authority" : "HEARTLAND Protocol (independent peer-reviewed open project)",
+    "country" : "us",
+    "history" : "https://fhir.heartlandprotocol.org",
+    "language" : ["en"],
+    "canonical" : "https://fhir.heartlandprotocol.org",
+    "ci-build" : "https://fhir.heartlandprotocol.org/ig",
+    "product" : ["fhir"],
+    "editions" : [{
+      "name" : "Release 0.1.0",
+      "ig-version" : "0.1.0",
+      "package" : "heartland.fhir.us.protocol#0.1.0",
+      "fhir-version" : ["4.0.1"],
+      "url" : "https://fhir.heartlandprotocol.org/ig"
+    }]
   }]
 }


### PR DESCRIPTION
## Summary

Adds the **HEARTLAND Protocol FHIR Implementation Guide** to the registry.

HEARTLAND is an open, peer-reviewed clinical implementation toolkit for primary-care-led heart failure management in rural and resource-limited US settings. The IG is the FHIR R4 companion to the protocol, defining profiles, extensions, questionnaires, and value sets for risk stratification, facility tier assignment, patient track assignment, and remote monitoring observations.

## Entry details

- **Name:** HEARTLAND Protocol FHIR Implementation Guide
- **Category:** Quality / CDS
- **Package ID:** heartland.fhir.us.protocol
- **Canonical:** https://fhir.heartlandprotocol.org
- **CI build:** https://fhir.heartlandprotocol.org/ig
- **Country:** us
- **FHIR Version:** 4.0.1
- **Authority:** HEARTLAND Protocol (independent peer-reviewed open project)
- **License:** CC BY 4.0 (content), MIT/Apache (code) — fully open, no fees, no commercial entity

## Provenance

- Peer-reviewed publication: Muller Ferreira V. *HEARTLAND Protocol — A Clinical Implementation Toolkit for Primary-Care-Led HF Management in Rural and Resource-Limited US Settings.* Cureus, 2026.
  - DOI: [10.7759/cureus.104817](https://doi.org/10.7759/cureus.104817)
  - PubMed: https://pubmed.ncbi.nlm.nih.gov/41948265/
- IG Zenodo deposit: [10.5281/zenodo.19634998](https://doi.org/10.5281/zenodo.19634998)
- Independent third-party indexing: RHIhub Resource Library record [#27888](https://www.ruralhealthinfo.org/resources/27888) (HRSA-funded clearinghouse, added 2026-05-07)

## Validation

- JSON validated locally (393 total guides after this addition)
- Canonical URL returns 200
- package.tgz served at canonical
- IG output follows standard FHIR IG Publisher layout

Author: Vicky Muller Ferreira, MD · ORCID [0009-0009-1099-5690](https://orcid.org/0009-0009-1099-5690)