### PR TITLE
Add Echidna Terminology Server registry

### DIFF
--- a/tx-servers.json
+++ b/tx-servers.json
@@ -69,6 +69,12 @@
       "name": "HL7 Germany Terminology Server",
       "authority": "Published by HL7 Germany",
       "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-de-tx-servers.json"
+    },
+    {
+      "code": "echidna",
+      "name": "Echidna Terminology Server",
+      "authority": "Published by Echidna Systems",
+      "url": "https://tx.echidna.systems/tx-servers.json"
     }
   ]
 }


### PR DESCRIPTION
Registers Echidna Systems' server list (https://tx.echidna.systems/tx-servers.json) as a new `tx-servers.json` entry. The server provides the OMOP vocabulary code system (URI: https://fhir-terminology.ohdsi.org) and supports FHIR R4 and R5.