### PR TITLE
Update DK Core FHIR IG version to 3.7.0

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -2110,10 +2110,10 @@
     "product" : ["fhir"],
     "editions" : [{
       "name" : "Release",
-      "ig-version" : "3.6.0",
-      "package" : "hl7.fhir.dk.core#3.6.0",
+      "ig-version" : "3.7.0",
+      "package" : "hl7.fhir.dk.core#3.7.0",
       "fhir-version" : ["4.0.1"],
-      "url" : "http://hl7.dk/fhir/core/3.6.0"
+      "url" : "http://hl7.dk/fhir/core/3.7.0"
     }]
   },
   {


### PR DESCRIPTION
This pull request updates the Danish Core Implementation Guide entry in the `fhir-ig-list.json` file to reference its latest release.

- Updated the Danish Core IG edition to version 3.7.0, including the `ig-version`, package identifier, and documentation URL.