### PR TITLE
Add Stroke FHIR Implementation Guide - M-CareTech Company

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -9888,7 +9888,6 @@
       "authority": "M-CareTech",
       "country": "br",
       "language": ["en"],
-      "history": "https://m-caretech.com.br/interopera/stroke-fhirig/index.html",
       "canonical": "https://m-caretech.com.br/interopera/stroke-fhirig",
       "ci-build": "https://m-caretech.com.br/interopera/stroke-fhirig",
       "product": ["fhir"],

--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -9881,6 +9881,35 @@
     }]
   },
   {
+     "name": "FHIR Implementation Guide for Stroke",
+      "category": "Clinical Registries",
+      "npm-name": "mcaretech.stroke.vbhc",
+      "description": "FHIR Implementation Guide for Stroke: a dual focus on the patient journey and outcome measures, supporting interoperability, care pathway monitoring, and value-based healthcare analysis.",
+      "authority": "M-CareTech",
+      "country": "br",
+      "language": ["en"],
+      "history": "https://m-caretech.com.br/interopera/stroke-fhirig/index.html",
+      "canonical": "https://m-caretech.com.br/interopera/stroke-fhirig",
+      "ci-build": "https://m-caretech.com.br/interopera/stroke-fhirig",
+      "product": ["fhir"],
+      "implementations": [
+        {
+          "name": "Source Code",
+          "type": "source",
+          "url": "https://github.com/gabriellesantosleandro/stroke-fhirig"
+        }
+      ],
+      "editions": [
+        {
+          "name": "Release 1.0.0",
+          "ig-version": "1.0.0",
+          "package": "mcaretech.stroke.vbhc#1.0.0",
+          "fhir-version": ["4.0.1"],
+          "url": "https://m-caretech.com.br/interopera/stroke-fhirig"
+        }
+      ] 
+  },
+  {
     "name" : "De-identification, Anonymization and Redaction Toolkit Services (DARTS) FHIR IG",
     "category" : "Privacy / Security",
     "npm-name" : "hl7.fhir.us.darts",


### PR DESCRIPTION
This pull request adds the FHIR Implementation Guide for Stroke developed by M-CareTech.

The guide focuses on interoperability for stroke care, supporting patient journey monitoring, outcome measures, and value-based healthcare analysis using HL7 FHIR R4.

Package: mcaretech.stroke.vbhc#1.0.0
Canonical URL: https://m-caretech.com.br/interopera/stroke-fhirig
FHIR version: 4.0.1
Source repository: https://github.com/gabriellesantosleandro/stroke-fhirig