### PR TITLE
Add additional codesystems for Danish usage

### DIFF
--- a/hl7-nordics-tx-servers.json
+++ b/hl7-nordics-tx-servers.json
@@ -12,7 +12,9 @@
             "http://snomed.info/sct|http://snomed.info/sct/554471000005108*",
             "http://snomed.info/sct|http://snomed.info/sct/51000202101*",
             "http://snomed.info/sct|http://snomed.info/sct/45991000052106*",
-            "urn:oid:1.2.208.176.2.4"
+            "urn:oid:1.2.208.176.2.4",
+            "urn:oid:1.2.208.176.2.4.12",
+            "http://hl7.dk/fhir/core/CodeSystem/icd10-danish-extensions"
         ],
         "authoritative-valuesets": [
         ],


### PR DESCRIPTION
This pull request updates the list of supported code systems in the `hl7-nordics-tx-servers.json` configuration file by adding new identifiers for Danish health data standards.

Additions to supported code systems:

* Added `"urn:oid:1.2.208.176.2.4.12"` to the list, expanding support for an additional Danish OID.
* Added `"http://hl7.dk/fhir/core/CodeSystem/icd10-danish-extensions"` to support Danish ICD-10 extensions.