### PR TITLE
Re-add NZ to tx-servers.json and update access info

### DIFF
--- a/hl7-nz-tx-servers.json
+++ b/hl7-nz-tx-servers.json
@@ -4,7 +4,7 @@
   "servers" : [{
     "code" : "nzhts",
     "name" : "New Zealand Health Terminology Service (NZHTS)",
-    "access_info" : "This server requires an API Key - see https://www.tewhatuora.govt.nz/health-services-and-programmes/digital-health/terminology-service",
+    "access_info" : "This server requires an API Key - see https://www.healthnz.govt.nz/health-professionals/guidance-standards/topic/data-and-standards/health-information-standards/nz-health-terminology-service-nzhts",
     "url" : "https://nzhts.digital.health.nz/fhir",
     "authoritative" : [
        "http://snomed.info/sct|http://snomed.info/sct/21000210109*"

--- a/tx-servers.json
+++ b/tx-servers.json
@@ -69,6 +69,12 @@
       "name": "HL7 Germany Terminology Server",
       "authority": "Published by HL7 Germany",
       "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-de-tx-servers.json"
+    },
+    {
+      "code": "hl7-nz",
+      "name": "HL7 New Zealand / New Zealand Health Terminology Service",
+      "authority": "Published by Health New Zealand / HL7 New Zealand",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-nz-tx-servers.json"
     }
   ]
 }


### PR DESCRIPTION
We have updated NZHTS's version of Onto and now have a process in place to keep it up to date with regular upgrades. 

PR is to:
* re-add us to the tx ecosystem to allow SNOMED NZ edition to be handled by NZHTS
* update contact URL for API key if needed for licensed content as the website moved.