### PR TITLE
Update BE TX to use SSL

### DIFF
--- a/hl7-be-tx-servers.json
+++ b/hl7-be-tx-servers.json
@@ -5,7 +5,7 @@
     "code" : "fps-be-tx",
     "name" : "Federal Public Service Health, Food Chain Safety and Environment",
     "access_info" : "This server is open to publishers of IGs",
-    "url" : "http://178.104.103.200/tx/r4",
+    "url" : "http://178.104.103.200.sslip.io/tx/r4",
     "usage": ["publication"],
     "authoritative" : [
       "http://snomed.info/sct|http://snomed.info/sct/11000172109*"

--- a/hl7-be-tx-servers.json
+++ b/hl7-be-tx-servers.json
@@ -12,7 +12,7 @@
     ],
     "fhirVersions" : [{
       "version" : "R4",
-      "url" : "http://178.104.103.200/tx/r4"
+      "url" : "https://178.104.103.200.sslip.io/tx/r4"
     }]
   }]
 }


### PR DESCRIPTION
We currently get a 
Error accessing https://178.104.103.200/tx/r4 for http://snomed.info/sct|http://snomed.info/sct/11000172109: Error fetching the server's capability statement: Received fatal alert: internal_error

So we added a temporary dns name on our temp server.