### PR TITLE
Include hl7.cz terminology server into ecosystem

### DIFF
--- a/hl7-cz-tx-servers.json
+++ b/hl7-cz-tx-servers.json
@@ -1,0 +1,42 @@
+{
+  "formatVersion": "1",
+  "description": "Registry of FHIR Terminology Servers in the Czech Republic",
+  "servers": [
+    {
+      "code": "hl7-cz",
+      "name": "HL7 Czech Republic Terminology Server",
+      "access_info": "Open FHIR Terminology Server supporting publication and validation of Czech FHIR Implementation Guides. Provides Czech national terminologies, SNOMED CT Czech Republic Edition and selected international terminologies with Czech language designations where available.",
+      "url": "https://tx.hl7.cz",
+      "fhirVersions": [
+        {
+          "version": "R4",
+          "url": "https://tx.hl7.cz/tx/r4"
+        },
+        {
+          "version": "R5",
+          "url": "https://tx.hl7.cz/tx/r5"
+        }
+      ],
+      "usage" : [
+      ],
+      "authoritative": [
+        "https://hl7.cz/terminology/CodeSystem*",
+        "https://ncez.mzcr.cz/terminology/CodeSystem*",
+        "http://snomed.info/sct|http://snomed.info/sct/11000279109*",
+        "https://ncez.mzcr.cz/nclp/CodeSystem*",
+        "https://sukl.cz/terminology/CodeSystem*",
+        "https://uzis.cz/terminology/CodeSystem*"
+      ],
+      "authoritative-valuesets": [
+        "https://hl7.cz/terminology/ValueSet*",
+        "https://ncez.mzcr.cz/terminology/ValueSet*",
+        "https://uzis.cz/terminology/ValueSet*"
+      ],
+      "notes": [
+        "The server provides SNOMED CT Czech Republic Edition, subject to SNOMED International licensing conditions.",
+        "The server provides Czech designations for LOINC where available. The LOINC CodeSystem remains authoritative at loinc.org.",
+        "Czech designations may be provided either directly in the CodeSystem resources or through CodeSystem supplements."
+      ]
+    }
+  ]
+}

--- a/hl7-cz-tx-servers.json
+++ b/hl7-cz-tx-servers.json
@@ -10,11 +10,11 @@
       "fhirVersions": [
         {
           "version": "R4",
-          "url": "https://tx.hl7.cz/tx/r4"
+          "url": "https://tx.hl7.cz/r4"
         },
         {
           "version": "R5",
-          "url": "https://tx.hl7.cz/tx/r5"
+          "url": "https://tx.hl7.cz/r5"
         }
       ],
       "usage" : [

--- a/hl7-eu-tx-servers.json
+++ b/hl7-eu-tx-servers.json
@@ -9,7 +9,6 @@
       "url": "http://tx.hl7europe.eu",
       "authoritative": [
         "http://hl7europe.org/fhir/terminology/ehdsi*",
-        "http://snomed.info/sct|http://snomed.info/sct/11000279109*",
         "http://npu-terminology.org"
       ],
       "authoritative-valuesets": [
@@ -27,7 +26,7 @@
         {
           "version": "R5",
           "url": "http://tx.hl7europe.eu/r5"
-        }        
+        }
       ]
     }
   ]

--- a/tx-servers.json
+++ b/tx-servers.json
@@ -63,6 +63,12 @@
       "name": "HL7 Nordics Terminology Server",
       "authority": "Published by nordic HL7 affiliates",
       "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-nordics-tx-servers.json"
+    },
+    {
+      "code": "hl7-cz",
+      "name": "HL7 Czech Republic Terminology Services",
+      "authority": "Published by HL7 Czech Republic",
+      "url": "https://raw.githubusercontent.com/FHIR/ig-registry/master/hl7-cz-tx-servers.json"
     }
   ]
 }


### PR DESCRIPTION
HL7-cz terminology server using latest Fhirsmith has been deplyed and is now publically available. 