### PR TITLE
Remove USCore Test Server and Source Code

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -7,16 +7,6 @@
     "authority" : "HL7",
     "country" : "us",
     "language" : ["en"],
-    "implementations" : [{
-      "name" : "Test Server",
-      "type" : "server",
-      "url" : "http://test.fhir.org"
-    },
-    {
-      "name" : "Source Code",
-      "type" : "source",
-      "url" : "http://github.com/HealthIntersections/fhirserver"
-    }],
     "history" : "http://hl7.org/fhir/us/core/history.html",
     "canonical" : "http://hl7.org/fhir/us/core",
     "ci-build" : "http://build.fhir.org/ig/HL7/US-Core",


### PR DESCRIPTION
Someone reported that the link to the Test Server for US Core in the IG registry entry doesn't resolve.

https://chat.fhir.org/user_uploads/10155/HGxw7X4TCr3puuOM2hsuRdPy/image.png


Removed implementation entries for Test Server and Source Code.