### PR TITLE
Adding OID for PIQI, .82 since after FAST PR

### DIFF
--- a/oid-assignments.json
+++ b/oid-assignments.json
@@ -85,6 +85,7 @@
     "2.16.840.1.113883.4.642.40.79" : {   "id" : "hl7.fhir.uv.aitransparency",                    "info" : "John Moehrke, 23-Jul 2026" },
     "2.16.840.1.113883.4.642.40.80" : {   "id" : "hl7.fhir.uv.omop",                              "info" : "Grahme Grieve, 29-Jul 2026" },
     
+    "2.16.840.1.113883.4.642.40.82" : {   "id" : "hl7.xprod.uv.piqi",                              "info" : "John D'Amore, 30-Jul 2026" },
     "1.3.6.1.4.1.19376.1.5.3.1.3.43" : {  "id" : "ihe.pcc.odh",                                   "info" : "John Moehrke, 04-Nov 2024" },
 
     "2.16.840.1.113883.2.51.22.1"   : {  "id" : "hl7.fhir.eu.laboratory",                         "info" : "Giorgio Cangioli, 19-Mar 2025" },


### PR DESCRIPTION
Adding an OID for the PIQI guide: https://build.fhir.org/ig/HL7/piqi/en/ 
We went for "2.16.840.1.113883.4.642.40.82" since https://github.com/FHIR/ig-registry/pull/633 is already asking for ".81" but happy to use whatever number is preferred. 



