### PR TITLE
update fhir-ig-list.json for nz base v3.1.0 release

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -130,22 +130,19 @@
     "npm-name" : "fhir.org.nz.ig.base",
     "description" : "Base New Zealand national implementation guide",
     "authority" : "HL7",
-    "product" : ["fhir"],
     "country" : "nz",
     "language" : ["en"],
     "canonical" : "http://fhir.org.nz/ig/base",
     "history" : "https://fhir.org.nz/ig/base/package-list.json",
-    "ci-build" : "http://build.fhir.org/ig/HL7NZ/nzbase/branches/master/index.html",
+    "ci-build" : "http://build.fhir.org/ig/HL7NZ/nzbase",
+    "product" : ["fhir"],
     "editions" : [{
-      "name" : "Release 3",
-      "ig-version" : "3.0.0",
-      "package" : "fhir.org.nz.ig.base#3.0.0",
+      "name" : "Releases",
+      "ig-version" : "3.1.0",
+      "package" : "fhir.org.nz.ig.base#3.1.0",
       "fhir-version" : ["4.0.1"],
-      "url" : "http://fhir.org.nz/ig/base"
-    }],
-    "analysis" : {
-      "error" : "Error fetching package directly (http://fhir.org.nz/ig/base/1.0.0/package.tgz), or fetching package list for fhir.org.nz.ig.base from http://fhir.org.nz/ig/base/package-list.json: Unable to fetch: Invalid HTTP response 404 from https://fhir.org.nz/ig/base/1.0.0/package.tgz (Not Found) (content in /var/folders/85/j9nrkr152ds51j69d7nrxq7r0000gn/T/fhir-http-6.log)"
-    }
+      "url" : "http://fhir.org.nz/ig/base/3.1.0"
+    }]
   },
   {
     "name" : "UZ Core",


### PR DESCRIPTION
fhir-ig-list.json update to add 3.1.0 release of NZ Base to https://fhir.org/guides/registry/ 