### PR TITLE
Update OID assignments and fix duplicates

### DIFF
--- a/oid-assignments.json
+++ b/oid-assignments.json
@@ -91,6 +91,7 @@
     "1.3.6.1.4.1.19376.1.5.3.1.3.43" : {  "id" : "ihe.pcc.odh",                                   "info" : "John Moehrke, 04-Nov 2024" },
 
     "2.16.840.1.113883.2.51.22.1"   : {  "id" : "hl7.fhir.eu.laboratory",                         "info" : "Giorgio Cangioli, 19-Mar 2025" },
-    "2.16.840.1.113883.2.51.22.2"   : {  "id" : "hl7.fhir.be.pss",                                "info" : "Grahame Grieve, 12-May 2025" }
+    "2.16.840.1.113883.2.51.22.2"   : {  "id" : "hl7.fhir.be.pss",                                "info" : "Grahame Grieve, 12-May 2025" },
+    "2.16.840.1.113883.2.22.40.1"   : {  "id" : "hl7.fhir.cl.minsal.eis",                         "info" : "Franco Ulloa, 04-Aug 2026"}
   }
 }


### PR DESCRIPTION
Added new OIDs Chile EIS and updated existing entries in the oid-assignments.json file. Included corrections for wrongly double assigned OIDs.