### PR TITLE
Add DHP Integrations Uzbekistan package feed

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -297,6 +297,11 @@
       "errors": "fhir|vadimperetok.in"
     },
     {
+      "name": "DHP Integrations Uzbekistan Packages",
+      "url": "https://raw.githubusercontent.com/uzinfocom-org/digital-health-integration/refs/heads/main/docs/package-feed.xml",
+      "errors": "fhir|vadimperetok.in"
+    },
+    {
       "name": "CSIRO FHIR Implementation Guides",
       "url": "https://starsapi.csiro.au/fhir-ig/package-feed.xml",
       "errors": "stars-support|csiro_au"


### PR DESCRIPTION
Adds the package feed for `uz.dhp.integrations`, the Uzbekistan Digital Health Platform integrations IG published by Uzinfocom.

- Feed: https://raw.githubusercontent.com/uzinfocom-org/digital-health-integration/refs/heads/main/docs/package-feed.xml
- Canonical: https://dhp.uz/fhir/integrations
- First release: `uz.dhp.integrations#0.7.0`

It sits alongside the existing "DHP & UZ Core Uzbekistan Packages" entry, which covers `uz.dhp.core` from a separate repository, and uses the same error contact.