### PR TITLE
Add package restriction for dvmd.kdl.r4

### DIFF
--- a/package-feeds.json
+++ b/package-feeds.json
@@ -560,6 +560,10 @@
     {
       "mask": "de.medizininformatikinitiative.kerndatensatz.base",
       "feeds": ["https://raw.githubusercontent.com/medizininformatik-initiative/kerndatensatz-basis/gh-pages/package-feed.xml"]
+    },
+    {
+      "mask": "dvmd.kdl.r4",
+      "feeds": [ "https://terminologien.bfarm.de/feeds?publishToHl7=true" ]
     }
   ]
 


### PR DESCRIPTION
Adds the KDL R4 package (`dvmd.kdl.r4`) to the package feed restrictions.

The package is provided through the ZTS terminology feed:
https://terminologien.bfarm.de/feeds?publishToHl7=true