### PR TITLE
Add iCoverU Cancer Insurance Implementation Guide

### DIFF
--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -10326,4 +10326,24 @@
       "url" : "http://fhir.org/guides/cdc/opioid-cds/2022.1.1"
     }]
   }]
+},
+{
+  "name": "iCoverU Cancer Insurance Implementation Guide",
+  "category": "Financial",
+  "npm-name": "fhir.icoveru.cancer",
+  "description": "A FHIR R4 Implementation Guide for cancer-related commercial insurance claim estimation in Taiwan. It defines profiles, extensions, terminology, and examples for representing patients, insurance coverage, cancer diagnoses, clinical evidence, claims, coverage eligibility, and estimated insurance benefit calculations.",
+  "authority": "iCoverU",
+  "product": ["fhir"],
+  "country": "tw",
+  "language": ["zh"],
+  "canonical": "https://cfhir.icoveru.com.tw",
+  "editions": [{
+    "name": "Release 1",
+    "ig-version": "0.1.0",
+    "package": "fhir.icoveru.cancer#0.1.0",
+    "fhir-version": ["4.0.1"],
+    "url": "https://cfhir.icoveru.com.tw/0.1.0/"
+    }]
+  }
+ ]
 }

--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -10325,7 +10325,6 @@
       "fhir-version" : ["4.0.1"],
       "url" : "http://fhir.org/guides/cdc/opioid-cds/2022.1.1"
     }]
-  }]
 },
 {
   "name": "iCoverU Cancer Insurance Implementation Guide",

--- a/fhir-ig-list.json
+++ b/fhir-ig-list.json
@@ -10341,7 +10341,7 @@
     "ig-version": "0.1.0",
     "package": "fhir.icoveru.cancer#0.1.0",
     "fhir-version": ["4.0.1"],
-    "url": "https://cfhir.icoveru.com.tw/0.1.0/"
+    "url": "https://cfhir.icoveru.com.tw/0.1.0"
     }]
   }
  ]


### PR DESCRIPTION
Add the iCoverU Cancer Insurance Implementation Guide to the FHIR Implementation Guide Registry.

This is a FHIR R4 Implementation Guide for cancer-related commercial insurance claim estimation in Taiwan.

IG details:
- Package: fhir.icoveru.cancer
- Version: 0.1.0
- FHIR Version: 4.0.1
- Country: Taiwan (tw)
- Category: Financial
- Authority: iCoverU
- Canonical: https://cfhir.icoveru.com.tw
- Published version: https://cfhir.icoveru.com.tw/0.1.0/

The published IG and versioned release are publicly accessible at the URLs above.